### PR TITLE
LENS-3093: search token generation fixes

### DIFF
--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -44,8 +44,7 @@ const getPublicApiKey = () => {
 
 export const engineConfig: CommerceEngineDefinitionOptions = {
   configuration: {
-    // accessToken: getPublicApiKey(),
-    accessToken: await getSearchToken(),
+    accessToken: getPublicApiKey(),
     organizationId: 'barcagroupproductionkwvdy6lp',
     analytics: {
       enabled: true,

--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -32,15 +32,20 @@ import {updateTokenIfNeeded} from '~/lib/token-utils';
 // first loads, the /token route might not be ready. As a backup, we can
 // pass an empty, invalid value. Later in this file, we use the `updateTokenIfNeeded`
 // function to update invalid or outdated tokens before interacting with Coveo APIs.
-const getAccessToken = async (usePublicApiKey: boolean) => {
-  return usePublicApiKey || typeof window !== 'undefined'
-    ? await fetchToken(null, usePublicApiKey)
+const getSearchToken = async () => {
+  return typeof window !== 'undefined'
+    ? await fetchToken()
     : '';
+};
+
+const getPublicApiKey = () => {
+  return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a';
 };
 
 export const engineConfig: CommerceEngineDefinitionOptions = {
   configuration: {
-    accessToken: await getAccessToken(false),
+    // accessToken: getPublicApiKey(),
+    accessToken: await getSearchToken(),
     organizationId: 'barcagroupproductionkwvdy6lp',
     analytics: {
       enabled: true,

--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -41,7 +41,7 @@ const getAccessToken = async (usePublicApiKey: boolean) => {
 export const engineConfig: CommerceEngineDefinitionOptions = {
   configuration: {
     accessToken: await getAccessToken(false),
-    organizationId: 'simonshopifytestj1yywg6i',
+    organizationId: 'barcagroupproductionkwvdy6lp',
     analytics: {
       enabled: true,
       trackingId: 'shop_en_us',

--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -41,7 +41,7 @@ const getAccessToken = async (usePublicApiKey: boolean) => {
 export const engineConfig: CommerceEngineDefinitionOptions = {
   configuration: {
     accessToken: await getAccessToken(false),
-    organizationId: 'barcagroupproductionkwvdy6lp',
+    organizationId: 'simonshopifytestj1yywg6i',
     analytics: {
       enabled: true,
       trackingId: 'shop_en_us',

--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -40,7 +40,7 @@ const getAccessToken = async (usePublicApiKey: boolean) => {
 
 export const engineConfig: CommerceEngineDefinitionOptions = {
   configuration: {
-    accessToken: await getAccessToken(true),
+    accessToken: await getAccessToken(false),
     organizationId: 'barcagroupproductionkwvdy6lp',
     analytics: {
       enabled: true,

--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -34,7 +34,7 @@ import {updateTokenIfNeeded} from '~/lib/token-utils';
 // function to update invalid or outdated tokens before interacting with Coveo APIs.
 const getAccessToken = async (usePublicApiKey: boolean) => {
   return usePublicApiKey || typeof window !== 'undefined'
-    ? await fetchToken(usePublicApiKey)
+    ? await fetchToken(null, usePublicApiKey)
     : '';
 };
 

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -21,10 +21,6 @@ export const fetchToken = async (request?: null | Request, apiKeyAuthentication 
 
 const headersToRelay = (request: Request) => {
   const headers = new Headers();
-  const authHeader = request.headers && request.headers.get('Authorization');
-  if (authHeader) {
-    headers.set('Authorization', authHeader);
-  }
 
   const cookieHeader = request.headers && request.headers.get('Cookie');
   if (cookieHeader) {

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -10,25 +10,11 @@ export const fetchToken = async (request: Request, apiKeyAuthentication = false)
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
-  const fetchWithRetry = async (retries: number, delay: number): Promise<TokenResponse> => {
-    try {
-      const response = await fetch(`${baseUrl}/token`);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch token: ${response.status} ${response.statusText}`);
-      }
-      const data = await response.json() as TokenResponse;
-      return data;
-    } catch (error) {
-      if (retries > 0) {
-        console.warn(`Retrying fetchToken... (${retries} retries left)`);
-        await new Promise((resolve) => setTimeout(resolve, delay)); // Add delay before retrying
-        return fetchWithRetry(retries - 1, delay);
-      }
-      console.error('Failed to fetch token after retries:', error);
-      throw error;
-    }
-  };
-
-  const tokenResponse = await fetchWithRetry(3, 1000); // Retry up to 3 times with a 1-second delay
-  return tokenResponse.token;
+  console.log ('fetching token from', `${baseUrl}/token`);
+  const response = await fetch(`${baseUrl}/token`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch token: ${response.status} ${response.statusText}`);
+  }
+  const data = await response.json() as TokenResponse;
+  return data.token;
 };

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -2,8 +2,10 @@ type TokenResponse = {
   token: string;
 };
 
-export const fetchToken = async (apiKeyAuthentication = true) => {
+export const fetchToken = async (request: Request, apiKeyAuthentication = false) => {
+  const baseUrl = request ? new URL(request.url).origin : '';
+
   return apiKeyAuthentication
     ? 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a' // demo api key
-    : ((await (await fetch('http://localhost:3000/token')).json()) as TokenResponse).token;
+    : ((await (await fetch(`${baseUrl}/token`)).json()) as TokenResponse).token;
 };

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -2,11 +2,7 @@ type TokenResponse = {
   token: string;
 };
 
-export const fetchToken = async (request?: null | Request, apiKeyAuthentication = false) => {
-  if (apiKeyAuthentication) {
-    return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
-  }
-
+export const fetchToken = async (request?: Request) => {
   const baseUrl = request && request.url ? new URL(request.url).origin : '';
   const headersToRelay = extractCookiesFromRequest(request);
   const sapiResponse = await fetch(`${baseUrl}/token`, { headers: headersToRelay });
@@ -16,7 +12,7 @@ export const fetchToken = async (request?: null | Request, apiKeyAuthentication 
   return ((await sapiResponse.json()) as TokenResponse).token;
 };
 
-const extractCookiesFromRequest = (request: Request | null | undefined) => {
+const extractCookiesFromRequest = (request?: Request) => {
   const headers = new Headers();
 
   const cookieHeader = request && request.headers && request.headers.get('Cookie');

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -3,12 +3,11 @@ type TokenResponse = {
 };
 
 export const fetchToken = async (request?: null | Request, apiKeyAuthentication = false) => {
-  const baseUrl = request && request.url ? new URL(request.url).origin : '';
-
   if (apiKeyAuthentication) {
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
+  const baseUrl = request && request.url ? new URL(request.url).origin : '';
   const headersToRelay = extractCookiesFromRequest(request);
   const sapiResponse = await fetch(`${baseUrl}/token`, { headers: headersToRelay });
   if (!sapiResponse.ok) {

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -3,7 +3,7 @@ type TokenResponse = {
 };
 
 export const fetchToken = async (request: Request, apiKeyAuthentication = false) => {
-  const baseUrl = request ? new URL(request.url).origin : '';
+  const baseUrl = request && request.url ? new URL(request.url).origin : '';
 
   return apiKeyAuthentication
     ? 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a' // demo api key

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -9,8 +9,6 @@ export const fetchToken = async (request?: null|Request, apiKeyAuthentication = 
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
-  console.log ('fetching token from', `${baseUrl}/token`);
-  console.log('with headers', request?.headers.get('Cookie'));
   const response = await fetch(`${baseUrl}/token`);
   if (!response.ok) {
     throw new Error(`Failed to fetch token: ${response.status} ${response.statusText}`);

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -2,17 +2,31 @@ type TokenResponse = {
   token: string;
 };
 
-export const fetchToken = async (request?: null|Request, apiKeyAuthentication = false) => {
+export const fetchToken = async (request?: null | Request, apiKeyAuthentication = false) => {
   const baseUrl = request && request.url ? new URL(request.url).origin : '';
 
   if (apiKeyAuthentication || typeof window == 'undefined') {
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
-  const response = await fetch(`${baseUrl}/token`);
+  const headers = new Headers();
+  if (request) {
+    // Relay headers from the incoming request
+    const authHeader = request.headers.get('Authorization');
+    if (authHeader) {
+      headers.set('Authorization', authHeader);
+    }
+
+    const cookieHeader = request.headers.get('Cookie');
+    if (cookieHeader) {
+      headers.set('Cookie', cookieHeader);
+    }
+  }
+
+  const response = await fetch(`${baseUrl}/token`, { headers });
   if (!response.ok) {
     throw new Error(`Failed to fetch token: ${response.status} ${response.statusText}`);
   }
-  const data = await response.json() as TokenResponse;
+  const data = (await response.json()) as TokenResponse;
   return data.token;
 };

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -5,7 +5,7 @@ type TokenResponse = {
 export const fetchToken = async (request?: null|Request, apiKeyAuthentication = false) => {
   const baseUrl = request && request.url ? new URL(request.url).origin : '';
 
-  if (apiKeyAuthentication) {
+  if (apiKeyAuthentication || typeof window == 'undefined') {
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -21,12 +21,12 @@ export const fetchToken = async (request?: null | Request, apiKeyAuthentication 
 
 const headersToRelay = (request: Request) => {
   const headers = new Headers();
-  const authHeader = request && request.headers && request.headers.get('Authorization');
+  const authHeader = request.headers && request.headers.get('Authorization');
   if (authHeader) {
     headers.set('Authorization', authHeader);
   }
 
-  const cookieHeader = request && request.headers && request.headers.get('Cookie');
+  const cookieHeader = request.headers && request.headers.get('Cookie');
   if (cookieHeader) {
     headers.set('Cookie', cookieHeader);
   }

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -10,7 +10,7 @@ export const fetchToken = async (request: Request, apiKeyAuthentication = false)
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
-  const fetchWithRetry = async (retries: number): Promise<TokenResponse> => {
+  const fetchWithRetry = async (retries: number, delay: number): Promise<TokenResponse> => {
     try {
       const response = await fetch(`${baseUrl}/token`);
       if (!response.ok) {
@@ -21,13 +21,14 @@ export const fetchToken = async (request: Request, apiKeyAuthentication = false)
     } catch (error) {
       if (retries > 0) {
         console.warn(`Retrying fetchToken... (${retries} retries left)`);
-        return fetchWithRetry(retries - 1);
+        await new Promise((resolve) => setTimeout(resolve, delay)); // Add delay before retrying
+        return fetchWithRetry(retries - 1, delay);
       }
       console.error('Failed to fetch token after retries:', error);
       throw error;
     }
   };
 
-  const tokenResponse = await fetchWithRetry(3); // Retry up to 3 times
+  const tokenResponse = await fetchWithRetry(3, 1000); // Retry up to 3 times with a 1-second delay
   return tokenResponse.token;
 };

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -6,7 +6,28 @@ export const fetchToken = async (request: Request, apiKeyAuthentication = false)
   const baseUrl = request && request.url ? new URL(request.url).origin : '';
   console.log('baseUrl', baseUrl);
 
-  return apiKeyAuthentication
-    ? 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a' // demo api key
-    : ((await (await fetch(`${baseUrl}/token`)).json()) as TokenResponse).token;
+  if (apiKeyAuthentication) {
+    return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
+  }
+
+  const fetchWithRetry = async (retries: number): Promise<TokenResponse> => {
+    try {
+      const response = await fetch(`${baseUrl}/token`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch token: ${response.status} ${response.statusText}`);
+      }
+      const data = await response.json() as TokenResponse;
+      return data;
+    } catch (error) {
+      if (retries > 0) {
+        console.warn(`Retrying fetchToken... (${retries} retries left)`);
+        return fetchWithRetry(retries - 1);
+      }
+      console.error('Failed to fetch token after retries:', error);
+      throw error;
+    }
+  };
+
+  const tokenResponse = await fetchWithRetry(3); // Retry up to 3 times
+  return tokenResponse.token;
 };

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -2,7 +2,7 @@ type TokenResponse = {
   token: string;
 };
 
-export const fetchToken = async (request: Request, apiKeyAuthentication = false) => {
+export const fetchToken = async (request?: null|Request, apiKeyAuthentication = false) => {
   const baseUrl = request && request.url ? new URL(request.url).origin : '';
   console.log('baseUrl', baseUrl);
 

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -4,6 +4,7 @@ type TokenResponse = {
 
 export const fetchToken = async (request: Request, apiKeyAuthentication = false) => {
   const baseUrl = request && request.url ? new URL(request.url).origin : '';
+  console.log('baseUrl', baseUrl);
 
   return apiKeyAuthentication
     ? 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a' // demo api key

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -9,7 +9,7 @@ export const fetchToken = async (request?: null | Request, apiKeyAuthentication 
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
-  const headers = request? headersToRelay(request) : new Headers();
+  const headers = relayRequestCookies(request);
 
   const response = await fetch(`${baseUrl}/token`, { headers });
   if (!response.ok) {
@@ -19,10 +19,10 @@ export const fetchToken = async (request?: null | Request, apiKeyAuthentication 
   return data.token;
 };
 
-const headersToRelay = (request: Request) => {
+const relayRequestCookies = (request: Request | null | undefined) => {
   const headers = new Headers();
 
-  const cookieHeader = request.headers && request.headers.get('Cookie');
+  const cookieHeader = request && request.headers && request.headers.get('Cookie');
   if (cookieHeader) {
     headers.set('Cookie', cookieHeader);
   }

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -9,17 +9,15 @@ export const fetchToken = async (request?: null | Request, apiKeyAuthentication 
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
-  const headers = relayRequestCookies(request);
-
-  const response = await fetch(`${baseUrl}/token`, { headers });
-  if (!response.ok) {
-    throw new Error(`Failed to fetch token: ${response.status} ${response.statusText}`);
+  const headersToRelay = extractCookiesFromRequest(request);
+  const sapiResponse = await fetch(`${baseUrl}/token`, { headers: headersToRelay });
+  if (!sapiResponse.ok) {
+    throw new Error(`Failed to fetch token: ${sapiResponse.status} ${sapiResponse.statusText}`);
   }
-  const data = (await response.json()) as TokenResponse;
-  return data.token;
+  return ((await sapiResponse.json()) as TokenResponse).token;
 };
 
-const relayRequestCookies = (request: Request | null | undefined) => {
+const extractCookiesFromRequest = (request: Request | null | undefined) => {
   const headers = new Headers();
 
   const cookieHeader = request && request.headers && request.headers.get('Cookie');

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -5,23 +5,11 @@ type TokenResponse = {
 export const fetchToken = async (request?: null | Request, apiKeyAuthentication = false) => {
   const baseUrl = request && request.url ? new URL(request.url).origin : '';
 
-  if (apiKeyAuthentication || typeof window == 'undefined') {
+  if (apiKeyAuthentication) {
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
-  const headers = new Headers();
-  if (request) {
-    // Relay headers from the incoming request
-    const authHeader = request.headers.get('Authorization');
-    if (authHeader) {
-      headers.set('Authorization', authHeader);
-    }
-
-    const cookieHeader = request.headers.get('Cookie');
-    if (cookieHeader) {
-      headers.set('Cookie', cookieHeader);
-    }
-  }
+  const headers = request? headersToRelay(request) : new Headers();
 
   const response = await fetch(`${baseUrl}/token`, { headers });
   if (!response.ok) {
@@ -30,3 +18,17 @@ export const fetchToken = async (request?: null | Request, apiKeyAuthentication 
   const data = (await response.json()) as TokenResponse;
   return data.token;
 };
+
+const headersToRelay = (request: Request) => {
+  const headers = new Headers();
+  const authHeader = request && request.headers && request.headers.get('Authorization');
+  if (authHeader) {
+    headers.set('Authorization', authHeader);
+  }
+
+  const cookieHeader = request && request.headers && request.headers.get('Cookie');
+  if (cookieHeader) {
+    headers.set('Cookie', cookieHeader);
+  }
+  return headers;
+}

--- a/app/lib/fetch-token.ts
+++ b/app/lib/fetch-token.ts
@@ -4,13 +4,13 @@ type TokenResponse = {
 
 export const fetchToken = async (request?: null|Request, apiKeyAuthentication = false) => {
   const baseUrl = request && request.url ? new URL(request.url).origin : '';
-  console.log('baseUrl', baseUrl);
 
   if (apiKeyAuthentication) {
     return 'xx697404a7-6cfd-48c6-93d1-30d73d17e07a'; // demo API key
   }
 
   console.log ('fetching token from', `${baseUrl}/token`);
+  console.log('with headers', request?.headers.get('Cookie'));
   const response = await fetch(`${baseUrl}/token`);
   if (!response.ok) {
     throw new Error(`Failed to fetch token: ${response.status} ${response.statusText}`);

--- a/app/lib/token-utils.ts
+++ b/app/lib/token-utils.ts
@@ -2,7 +2,7 @@ import { parse } from 'cookie';
 import { engineDefinition } from './coveo.engine';
 import {fetchToken} from '~/lib/fetch-token';
 
-function decodeBase64Url(base64Url: string): string {
+export function decodeBase64Url(base64Url: string): string {
   const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
   return atob(base64);
 }
@@ -44,7 +44,7 @@ export async function updateTokenIfNeeded(
       const accessTokenCookie = extractAccessTokenFromCookie(request)
       const accessToken =  accessTokenCookie && !isTokenExpired(accessTokenCookie)
         ? accessTokenCookie
-        : await fetchToken();
+        : await fetchToken(request);
 
         engineDefinition[engineType].setAccessToken(accessToken);
     }

--- a/app/routes/token.tsx
+++ b/app/routes/token.tsx
@@ -28,8 +28,8 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     );
   }
 
-  const newToken = await fetchTokenFromSAPI(context);
-  //const newToken = await fetchTokenFromAppProxy();
+  //const newToken = await fetchTokenFromSAPI(context);
+  const newToken = await fetchTokenFromAppProxy();
 
   const parsedToken = JSON.parse(decodeBase64Url(newToken.split('.')[1])) as ParsedToken;
   const maxAge = parsedToken.exp * 1000 - Date.now();

--- a/app/routes/token.tsx
+++ b/app/routes/token.tsx
@@ -28,8 +28,8 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     );
   }
 
-  const newToken = await fetchTokenFromSAPI(context);
-  // const newToken = await fetchTokenFromAppProxy();
+  // const newToken = await fetchTokenFromSAPI(context);
+  const newToken = await fetchTokenFromAppProxy();
 
   const parsedToken = JSON.parse(decodeBase64Url(newToken.split('.')[1])) as ParsedToken;
   const maxAge = parsedToken.exp * 1000 - Date.now();

--- a/app/routes/token.tsx
+++ b/app/routes/token.tsx
@@ -29,7 +29,6 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
   }
 
   const newToken = await fetchTokenFromSAPI(context);
-  //const newToken = await fetchTokenFromAppProxy();
 
   const parsedToken = JSON.parse(decodeBase64Url(newToken.split('.')[1])) as ParsedToken;
   const maxAge = parsedToken.exp * 1000 - Date.now();

--- a/app/routes/token.tsx
+++ b/app/routes/token.tsx
@@ -28,8 +28,8 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     );
   }
 
-  //const newToken = await fetchTokenFromSAPI(context);
-  const newToken = await fetchTokenFromAppProxy();
+  const newToken = await fetchTokenFromSAPI(context);
+  //const newToken = await fetchTokenFromAppProxy();
 
   const parsedToken = JSON.parse(decodeBase64Url(newToken.split('.')[1])) as ParsedToken;
   const maxAge = parsedToken.exp * 1000 - Date.now();

--- a/app/routes/token.tsx
+++ b/app/routes/token.tsx
@@ -28,8 +28,8 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     );
   }
 
-  // const newToken = await fetchTokenFromSAPI(context);
-  const newToken = await fetchTokenFromAppProxy();
+  const newToken = await fetchTokenFromSAPI(context);
+  //const newToken = await fetchTokenFromAppProxy();
 
   const parsedToken = JSON.parse(decodeBase64Url(newToken.split('.')[1])) as ParsedToken;
   const maxAge = parsedToken.exp * 1000 - Date.now();


### PR DESCRIPTION
Two updates following discussion with @olamothe 
- Set the token cookie expiration date based on the search token expiration field.
- In fetch-token.ts, added logic to retrieve the request cookies from the route being served to use them when calling the /token route. This is necessary in the preview environment. (you can see a [working example here](https://01js27jm7j63ka4h0pmmstgfrb-d563d36bb1f53df1c547.myshopify.dev/)). This was not an issue when I was only testing locally, but when deployed, Oxygen requires certain credentials when serving a route, and Shopify fills them in with browser cookies. If we call a route from the backend, we need to use those cookies.

Also, I tested that we can use tokens generated by the app proxy in the preview environment. 
See https://01js0nhdhysyex8mvryj1r7xts-d563d36bb1f53df1c547.myshopify.dev/search
(the token gets generated correctly, but it can't really make requests because the shopify app was linked to another org, which doesn't have the catalog setup to work with the Hydrogen project. But if you decode the token stored in your browser cookies you can see that it worked fine.
![Screenshot 2025-04-17 at 12 06 01 PM](https://github.com/user-attachments/assets/5ad5eded-fb2f-465d-be39-b3aa77cfd1fc)

)