### PR TITLE
LENS-3604: Add cart attributes for Coveo Shopify Web App to use

### DIFF
--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -37,7 +37,6 @@ export interface CartReturn {
   cart: Cart;
 }
 
-// TODO: For this branch update the fields here to be in Camel Case rather than snake case
 // Helper function to ensure Coveo client ID and tracking ID are set as cart attributes
 async function setCoveoConfigAttributes(
   context: any,

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -62,19 +62,19 @@ async function setCoveoConfigAttributes(
   const hasAttr = (key: string) => attributes.some((attr) => attr.key === key);
 
   if (!hasAttr('coveo_client_id')) {
-    attributesToUpdate.push({key: 'coveo_client_id', value: clientId});
+    attributesToUpdate.push({key: 'coveoClientId', value: clientId});
   }
   if (!hasAttr('coveo_tracking_id')) {
-    attributesToUpdate.push({key: 'coveo_tracking_id', value: trackingId});
+    attributesToUpdate.push({key: 'coveoTrackingId', value: trackingId});
   }
   if (!hasAttr('coveo_organization_id')) {
     attributesToUpdate.push({
-      key: 'coveo_organization_id',
+      key: 'coveoOrganizationId',
       value: organizationId,
     });
   }
   if (!hasAttr('coveo_access_token')) {
-    attributesToUpdate.push({key: 'coveo_access_token', value: accessToken});
+    attributesToUpdate.push({key: 'coveoAccessToken', value: accessToken});
   }
 
   let updatedResult = cartResult;

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -8,6 +8,7 @@ import {
   useLoaderData,
   useRouteLoaderData,
   type ActionFunctionArgs,
+  type AppLoadContext,
   type LoaderFunctionArgs,
   type MetaFunction,
 } from 'react-router';
@@ -39,7 +40,7 @@ export interface CartReturn {
 
 // Helper function to ensure the Web Pixel receives what it needs to emit Coveo cart events in the checkout page.
 async function setCoveoConfigAttributes(
-  context: any,
+  context: AppLoadContext,
   request: Request,
   cartResult: CartQueryDataReturn,
 ) {
@@ -48,12 +49,11 @@ async function setCoveoConfigAttributes(
 
   if (!cart) return cartResult;
 
-  const attributes = cart.attributes ?? [];
-  const attributesToUpdate = [];
+  const attributesToUpdate: {key: string; value: string}[] = [];
 
   const navigatorProvider = new ServerSideNavigatorContextProvider(request);
 
-  const {clientId} = navigatorProvider;
+  const clientId = navigatorProvider.clientId ?? '';
   const {
     configuration: {
       analytics: {trackingId},
@@ -69,12 +69,15 @@ async function setCoveoConfigAttributes(
     'coveoAccessToken',
   ];
 
-  const foundAttributes = (cart.attributes ?? []).reduce((acc, item) => {
-  if (attributesToFind.includes(item.key)) {
-    acc[item.key] = {key: item.key, value: item.value};
-  }
-    return acc;
-  }, {} as Record<string, {key: string; value: string}>);
+  const foundAttributes = (cart.attributes ?? []).reduce(
+    (acc, item) => {
+      if (attributesToFind.includes(item.key)) {
+        acc[item.key] = {key: item.key, value: item.value ?? ''};
+      }
+      return acc;
+    },
+    {} as Record<string, {key: string; value: string}>,
+  );
 
   if (!foundAttributes.coveoClientId) {
     attributesToUpdate.push({key: 'coveoClientId', value: clientId});

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -70,9 +70,9 @@ async function setCoveoConfigAttributes(
   ];
 
   const foundAttributes = (cart.attributes ?? []).reduce((acc, item) => {
-    if (attributesToFind.includes(item.key) && item.value != null) {
-      acc[item.key] = {key: item.key, value: item.value ?? ''};
-    }
+  if (attributesToFind.includes(item.key)) {
+    acc[item.key] = {key: item.key, value: item.value};
+  }
     return acc;
   }, {} as Record<string, {key: string; value: string}>);
 

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -18,7 +18,7 @@ import {
   RecommendationProvider,
   StandaloneProvider,
 } from '~/components/Search/Context';
-import {engineDefinition} from '~/lib/coveo/engine';
+import {engineConfig, engineDefinition} from '~/lib/coveo/engine';
 import {
   fetchRecommendationStaticState,
   fetchStandaloneStaticState,
@@ -35,6 +35,60 @@ export const meta: MetaFunction = () => {
 
 export interface CartReturn {
   cart: Cart;
+}
+
+// Helper function to ensure Coveo client ID and tracking ID are set as cart attributes
+async function setCoveoConfigAttributes(
+  context: any,
+  request: Request,
+  cartResult: CartQueryDataReturn,
+) {
+  const {cart: cartHandler} = context;
+  const cart = cartResult.cart;
+
+  if (!cart) return cartResult;
+
+  const existingCoveoClientId = cart.attributes?.find(
+    (attr) => attr.key === 'coveo_client_id',
+  );
+
+  const existingCoveoTrackingId = cart.attributes?.find(
+    (attr) => attr.key === 'coveo_tracking_id',
+  );
+
+  const navigatorProvider = new ServerSideNavigatorContextProvider(request);
+  const clientId = navigatorProvider.clientId;
+
+  // Get tracking ID from engine config
+  const trackingId = engineConfig.configuration.analytics?.trackingId || 'shop_en_us';
+
+  // Set cart attributes if missing
+  let updatedResult = cartResult;
+  const attributesToUpdate = [];
+
+  if (!existingCoveoClientId) {
+    attributesToUpdate.push({
+      key: 'coveo_client_id',
+      value: clientId,
+    });
+  }
+
+  if (!existingCoveoTrackingId) {
+    attributesToUpdate.push({
+      key: 'coveo_tracking_id',
+      value: trackingId,
+    });
+  }
+
+  if (attributesToUpdate.length > 0) {
+    try {
+      updatedResult = await cartHandler.updateAttributes(attributesToUpdate);
+    } catch (error) {
+      console.warn('Failed to set Coveo attributes:', error);
+    }
+  }
+
+  return updatedResult;
 }
 
 export async function action({request, context}: ActionFunctionArgs) {
@@ -63,29 +117,19 @@ export async function action({request, context}: ActionFunctionArgs) {
       break;
     case CartForm.ACTIONS.DiscountCodesUpdate: {
       const formDiscountCode = inputs.discountCode;
-
-      // User inputted discount code
       const discountCodes = (
         formDiscountCode ? [formDiscountCode] : []
       ) as string[];
-
-      // Combine discount codes already applied on cart
       discountCodes.push(...inputs.discountCodes);
-
       result = await cart.updateDiscountCodes(discountCodes);
       break;
     }
     case CartForm.ACTIONS.GiftCardCodesUpdate: {
       const formGiftCardCode = inputs.giftCardCode;
-
-      // User inputted gift card code
       const giftCardCodes = (
         formGiftCardCode ? [formGiftCardCode] : []
       ) as string[];
-
-      // Combine gift card codes already applied on cart
       giftCardCodes.push(...inputs.giftCardCodes);
-
       result = await cart.updateGiftCardCodes(giftCardCodes);
       break;
     }
@@ -101,6 +145,9 @@ export async function action({request, context}: ActionFunctionArgs) {
 
   const cartId = result?.cart?.id;
   const headers = cartId ? cart.setCartId(result.cart.id) : new Headers();
+
+  result = await setCoveoConfigAttributes(context, request, result);
+
   const {cart: cartResult, errors, warnings} = result;
 
   return data(
@@ -117,6 +164,8 @@ export async function action({request, context}: ActionFunctionArgs) {
 }
 
 export async function loader({request, context}: LoaderFunctionArgs) {
+  const {cart} = context;
+
   // Set up navigator context for recommendations
   engineDefinition.recommendationEngineDefinition.setNavigatorContextProvider(
     () => new ServerSideNavigatorContextProvider(request),
@@ -139,6 +188,12 @@ export async function loader({request, context}: LoaderFunctionArgs) {
       context,
     }),
   ]);
+
+  // Get current cart and ensure Coveo client ID is set
+  const cartData = await cart.get();
+  if (cartData) {
+    await setCoveoConfigAttributes(context, request, {cart: cartData});
+  }
 
   return {
     recommendationStaticState: recommendationResult.staticState,

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -48,7 +48,7 @@ async function setCoveoConfigAttributes(
 
   if (!cart) return cartResult;
 
-  const attributes = cart.attributes;
+  const attributes = cart.attributes ?? [];
   const attributesToUpdate = [];
 
   const navigatorProvider = new ServerSideNavigatorContextProvider(request);
@@ -60,19 +60,19 @@ async function setCoveoConfigAttributes(
 
   const hasAttr = (key: string) => attributes.some((attr) => attr.key === key);
 
-  if (!hasAttr('coveo_client_id')) {
+  if (!hasAttr('coveoClientId')) {
     attributesToUpdate.push({key: 'coveoClientId', value: clientId});
   }
-  if (!hasAttr('coveo_tracking_id')) {
+  if (!hasAttr('coveoTrackingId')) {
     attributesToUpdate.push({key: 'coveoTrackingId', value: trackingId});
   }
-  if (!hasAttr('coveo_organization_id')) {
+  if (!hasAttr('coveoOrganizationId')) {
     attributesToUpdate.push({
       key: 'coveoOrganizationId',
       value: organizationId,
     });
   }
-  if (!hasAttr('coveo_access_token')) {
+  if (!hasAttr('coveoAccessToken')) {
     attributesToUpdate.push({key: 'coveoAccessToken', value: accessToken});
   }
 

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -37,6 +37,7 @@ export interface CartReturn {
   cart: Cart;
 }
 
+// TODO: For this branch update the fields here to be in Camel Case rather than snake case
 // Helper function to ensure Coveo client ID and tracking ID are set as cart attributes
 async function setCoveoConfigAttributes(
   context: any,
@@ -48,38 +49,35 @@ async function setCoveoConfigAttributes(
 
   if (!cart) return cartResult;
 
-  const existingCoveoClientId = cart.attributes?.find(
-    (attr) => attr.key === 'coveo_client_id',
-  );
-
-  const existingCoveoTrackingId = cart.attributes?.find(
-    (attr) => attr.key === 'coveo_tracking_id',
-  );
-
-  const navigatorProvider = new ServerSideNavigatorContextProvider(request);
-  const clientId = navigatorProvider.clientId;
-
-  // Get tracking ID from engine config
-  const trackingId = engineConfig.configuration.analytics?.trackingId || 'shop_en_us';
-
-  // Set cart attributes if missing
-  let updatedResult = cartResult;
+  const attributes = cart.attributes;
   const attributesToUpdate = [];
 
-  if (!existingCoveoClientId) {
+  const navigatorProvider = new ServerSideNavigatorContextProvider(request);
+
+  const clientId = navigatorProvider.clientId;
+  const trackingId = engineConfig.configuration.analytics.trackingId;
+  const organizationId = engineConfig.configuration.organizationId;
+  const accessToken = engineConfig.configuration.accessToken;
+
+  const hasAttr = (key: string) => attributes.some((attr) => attr.key === key);
+
+  if (!hasAttr('coveo_client_id')) {
+    attributesToUpdate.push({key: 'coveo_client_id', value: clientId});
+  }
+  if (!hasAttr('coveo_tracking_id')) {
+    attributesToUpdate.push({key: 'coveo_tracking_id', value: trackingId});
+  }
+  if (!hasAttr('coveo_organization_id')) {
     attributesToUpdate.push({
-      key: 'coveo_client_id',
-      value: clientId,
+      key: 'coveo_organization_id',
+      value: organizationId,
     });
   }
-
-  if (!existingCoveoTrackingId) {
-    attributesToUpdate.push({
-      key: 'coveo_tracking_id',
-      value: trackingId,
-    });
+  if (!hasAttr('coveo_access_token')) {
+    attributesToUpdate.push({key: 'coveo_access_token', value: accessToken});
   }
 
+  let updatedResult = cartResult;
   if (attributesToUpdate.length > 0) {
     try {
       updatedResult = await cartHandler.updateAttributes(attributesToUpdate);

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -37,7 +37,7 @@ export interface CartReturn {
   cart: Cart;
 }
 
-// Helper function to ensure Coveo client ID and tracking ID are set as cart attributes
+// Helper function to ensure the Web Pixel receives what it needs to emit Coveo cart events in the checkout page.
 async function setCoveoConfigAttributes(
   context: any,
   request: Request,

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -53,26 +53,42 @@ async function setCoveoConfigAttributes(
 
   const navigatorProvider = new ServerSideNavigatorContextProvider(request);
 
-  const clientId = navigatorProvider.clientId;
-  const trackingId = engineConfig.configuration.analytics.trackingId;
-  const organizationId = engineConfig.configuration.organizationId;
-  const accessToken = engineConfig.configuration.accessToken;
+  const {clientId} = navigatorProvider;
+  const {
+    configuration: {
+      analytics: {trackingId},
+      organizationId,
+      accessToken,
+    },
+  } = engineConfig;
 
-  const hasAttr = (key: string) => attributes.some((attr) => attr.key === key);
+  const attributesToFind = [
+    'coveoClientId',
+    'coveoTrackingId',
+    'coveoOrganizationId',
+    'coveoAccessToken',
+  ];
 
-  if (!hasAttr('coveoClientId')) {
+  const foundAttributes = (cart.attributes ?? []).reduce((acc, item) => {
+    if (attributesToFind.includes(item.key) && item.value != null) {
+      acc[item.key] = {key: item.key, value: item.value ?? ''};
+    }
+    return acc;
+  }, {} as Record<string, {key: string; value: string}>);
+
+  if (!foundAttributes.coveoClientId) {
     attributesToUpdate.push({key: 'coveoClientId', value: clientId});
   }
-  if (!hasAttr('coveoTrackingId')) {
+  if (!foundAttributes.coveoTrackingId) {
     attributesToUpdate.push({key: 'coveoTrackingId', value: trackingId});
   }
-  if (!hasAttr('coveoOrganizationId')) {
+  if (!foundAttributes.coveoOrganizationId) {
     attributesToUpdate.push({
       key: 'coveoOrganizationId',
       value: organizationId,
     });
   }
-  if (!hasAttr('coveoAccessToken')) {
+  if (!foundAttributes.coveoAccessToken) {
     attributesToUpdate.push({key: 'coveoAccessToken', value: accessToken});
   }
 


### PR DESCRIPTION
For handling the VisitorID with Headless and Shopify liquid, we need to ensure that certain attributes are added to the Cart Attributes for Shopify.

 These will get passed along in the `checkout_completed` event to be picked up by the Coveo Shopify App. 
 
[PR for Coveo Shopify App here](https://github.com/coveo-platform/coveo-shopify-app/pull/517)