### PR TITLE
UNI-1264: Barca Shop Source Update (clean)

### DIFF
--- a/.github/workflows/oxygen-deployment-1000027091.yml
+++ b/.github/workflows/oxygen-deployment-1000027091.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           node-version: 'lts/*'
           check-latest: true
-      - name: Install tailwind oxyde
-        run: npm i
 
       - name: Cache node modules
         id: cache-npm

--- a/.github/workflows/oxygen-deployment-1000027091.yml
+++ b/.github/workflows/oxygen-deployment-1000027091.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           node-version: 'lts/*'
           check-latest: true
+      - name: Install tailwind oxyde
+        run: npm i
 
       - name: Cache node modules
         id: cache-npm

--- a/app/components/AddToCartButton.tsx
+++ b/app/components/AddToCartButton.tsx
@@ -3,11 +3,11 @@ import {
   useSearchParams,
   type FetcherWithComponents,
 } from '@remix-run/react';
-import { CartForm, type OptimisticCartLineInput } from '@shopify/hydrogen';
-import { useCart } from '~/lib/coveo.engine';
-import { colorToShorthand } from '~/lib/map.coveo.shopify';
-import type { CartReturn } from '~/routes/($locale).cart';
-import type { ProductHandleData } from '~/routes/($locale).products.$handle';
+import {CartForm, type OptimisticCartLineInput} from '@shopify/hydrogen';
+import {useCart} from '~/lib/coveo.engine';
+import {colorToShorthand} from '~/lib/map.coveo.shopify';
+import type {CartReturn} from '~/routes/($locale).cart';
+import type {ProductHandleData} from '~/routes/($locale).products.$handle';
 import '~/types/gtm';
 
 export function AddToCartButton({
@@ -41,7 +41,7 @@ export function AddToCartButton({
     <CartForm
       fetcherKey="add-to-cart"
       route="/cart"
-      inputs={{ lines }}
+      inputs={{lines}}
       action={CartForm.ACTIONS.LinesAdd}
     >
       {(fetcher: FetcherWithComponents<CartReturn>) => {
@@ -62,22 +62,22 @@ export function AddToCartButton({
                   quantity: newQuantity,
                 });
                 window.dataLayer = window.dataLayer || [];
-                window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+                window.dataLayer.push({ecommerce: null}); // Clear the previous ecommerce object.
                 window.dataLayer.push({
-                  event: "add_to_cart",
+                  event: 'add_to_cart',
                   ecommerce: {
-                    currency: "USD",
+                    currency: 'USD',
                     value: Number(product.selectedVariant?.price.amount),
                     items: [
                       {
                         item_id: coveoProductId!,
                         item_name: product.title,
                         price: Number(product.selectedVariant?.price.amount),
-                        quantity: quantityToAdd
-                      }
-                    ]
-                  }
-                })
+                        quantity: quantityToAdd,
+                      },
+                    ],
+                  },
+                });
               }}
               className="add-to-cart flex max-w-xs flex-1 items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50 sm:w-full"
               type="submit"

--- a/app/components/AddToCartButton.tsx
+++ b/app/components/AddToCartButton.tsx
@@ -8,6 +8,7 @@ import { useCart } from '~/lib/coveo.engine';
 import { colorToShorthand } from '~/lib/map.coveo.shopify';
 import type { CartReturn } from '~/routes/($locale).cart';
 import type { ProductHandleData } from '~/routes/($locale).products.$handle';
+import '~/types/gtm';
 
 export function AddToCartButton({
   analytics,
@@ -60,11 +61,8 @@ export function AddToCartButton({
                   productId: coveoProductId!,
                   quantity: newQuantity,
                 });
-                //@ts-ignore
                 window.dataLayer = window.dataLayer || [];
-                //@ts-ignore
                 window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-                //@ts-ignore
                 window.dataLayer.push({
                   event: "add_to_cart",
                   ecommerce: {

--- a/app/components/Cart/CartLineItem.tsx
+++ b/app/components/Cart/CartLineItem.tsx
@@ -1,8 +1,8 @@
-import type { CartLineUpdateInput } from '@shopify/hydrogen/storefront-api-types';
-import { CartForm } from '@shopify/hydrogen';
-import { XMarkIcon as XMarkIconMini } from '@heroicons/react/20/solid';
-import { useCart } from '~/lib/coveo.engine';
-import type { CartItem } from '@coveo/headless-react/ssr-commerce';
+import type {CartLineUpdateInput} from '@shopify/hydrogen/storefront-api-types';
+import {CartForm} from '@shopify/hydrogen';
+import {XMarkIcon as XMarkIconMini} from '@heroicons/react/20/solid';
+import {useCart} from '~/lib/coveo.engine';
+import type {CartItem} from '@coveo/headless-react/ssr-commerce';
 import '~/types/gtm';
 
 /**
@@ -24,26 +24,27 @@ export function CartLineRemoveButton({
     <CartForm
       route="/cart"
       action={CartForm.ACTIONS.LinesRemove}
-      inputs={{ lineIds }}
+      inputs={{lineIds}}
     >
       <button
         onClick={() => {
           coveoCart.methods?.updateItemQuantity(cartItem);
           window.dataLayer = window.dataLayer || [];
-          window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+          window.dataLayer.push({ecommerce: null}); // Clear the previous ecommerce object.
           window.dataLayer.push({
-            event: "remove_from_cart",
+            event: 'remove_from_cart',
             ecommerce: {
-              currency: "USD",
+              currency: 'USD',
               value: cartItem.price,
-              items: [{
-                item_id: cartItem.productId,
-                item_name: cartItem.name,
-                price: cartItem.price
-              }]
-            }
+              items: [
+                {
+                  item_id: cartItem.productId,
+                  item_name: cartItem.name,
+                  price: cartItem.price,
+                },
+              ],
+            },
           });
-
 
           /*setTimeout(() => {
             window.location.reload();
@@ -71,7 +72,7 @@ export function CartLineUpdateButton({
     <CartForm
       route="/cart"
       action={CartForm.ACTIONS.LinesUpdate}
-      inputs={{ lines }}
+      inputs={{lines}}
     >
       {children}
     </CartForm>

--- a/app/components/Cart/CartLineItem.tsx
+++ b/app/components/Cart/CartLineItem.tsx
@@ -3,6 +3,7 @@ import { CartForm } from '@shopify/hydrogen';
 import { XMarkIcon as XMarkIconMini } from '@heroicons/react/20/solid';
 import { useCart } from '~/lib/coveo.engine';
 import type { CartItem } from '@coveo/headless-react/ssr-commerce';
+import '~/types/gtm';
 
 /**
  * A button that removes a line item from the cart. It is disabled
@@ -28,11 +29,8 @@ export function CartLineRemoveButton({
       <button
         onClick={() => {
           coveoCart.methods?.updateItemQuantity(cartItem);
-          //@ts-ignore
           window.dataLayer = window.dataLayer || [];
-          //@ts-ignore
           window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-          //@ts-ignore
           window.dataLayer.push({
             event: "remove_from_cart",
             ecommerce: {

--- a/app/components/Cart/CartMain.tsx
+++ b/app/components/Cart/CartMain.tsx
@@ -1,12 +1,12 @@
-import { NavLink } from '@remix-run/react';
-import { Money, useOptimisticCart } from '@shopify/hydrogen';
-import type { CartApiQueryFragment } from 'storefrontapi.generated';
-import { CheckIcon, QuestionMarkCircleIcon } from '@heroicons/react/20/solid';
-import { CartLineRemoveButton } from './CartLineItem';
-import { useCart } from '~/lib/coveo.engine';
+import {NavLink} from '@remix-run/react';
+import {Money, useOptimisticCart} from '@shopify/hydrogen';
+import type {CartApiQueryFragment} from 'storefrontapi.generated';
+import {CheckIcon, QuestionMarkCircleIcon} from '@heroicons/react/20/solid';
+import {CartLineRemoveButton} from './CartLineItem';
+import {useCart} from '~/lib/coveo.engine';
 import cx from '~/lib/cx';
-import type { CartLine } from '@shopify/hydrogen/storefront-api-types';
-import { mapShopifyMerchandiseToCoveoCartItem } from '~/lib/map.coveo.shopify';
+import type {CartLine} from '@shopify/hydrogen/storefront-api-types';
+import {mapShopifyMerchandiseToCoveoCartItem} from '~/lib/map.coveo.shopify';
 import '~/types/gtm';
 
 export type CartLayout = 'page' | 'aside';
@@ -15,7 +15,7 @@ export type CartMainProps = {
   cart: CartApiQueryFragment | null;
 };
 
-export function CartMain({ cart: originalCart }: CartMainProps) {
+export function CartMain({cart: originalCart}: CartMainProps) {
   // The useOptimisticCart hook applies pending actions to the cart
   // so the user immediately sees feedback when they modify the cart.
   const cart = useOptimisticCart(originalCart);
@@ -24,46 +24,46 @@ export function CartMain({ cart: originalCart }: CartMainProps) {
 
   const buildDataLayerForPurchase = (cart: any) => {
     if (!cart) {
-      console.error("Failed to fetch cart object. Aborting tracking!")
-      return
+      console.error('Failed to fetch cart object. Aborting tracking!');
+      return;
     }
     const purchaseDataLayerObject = {
-      event: "purchase",
+      event: 'purchase',
       ecommerce: {},
-    }
+    };
 
     // Assigning the transaction_id
-    const transaction_id = cart.id.split("key=")[1] || null
-    purchaseDataLayerObject.ecommerce.transaction_id = transaction_id
+    const transaction_id = cart.id.split('key=')[1] || null;
+    purchaseDataLayerObject.ecommerce.transaction_id = transaction_id;
 
     //Assigning the total value
-    const value = cart.cost.totalAmount.amount || null
-    purchaseDataLayerObject.ecommerce.value = value
+    const value = cart.cost.totalAmount.amount || null;
+    purchaseDataLayerObject.ecommerce.value = value;
 
     //Assigning transaction currency
-    const currency = cart.cost.totalAmount.currencyCode || null
-    purchaseDataLayerObject.ecommerce.currency = currency
+    const currency = cart.cost.totalAmount.currencyCode || null;
+    purchaseDataLayerObject.ecommerce.currency = currency;
 
     // Constructing the items array
 
-    const items = []
+    const items = [];
 
     if (cart.lines.nodes) {
       cart.lines.nodes.forEach((node, index) => {
         items.push({
           item_id: node.merchandise.product.handle,
           item_name: node.merchandise.product.title,
-          index: index,
+          index,
           price: node.merchandise.price.amount,
           quantity: node.quantity,
-        })
-      })
+        });
+      });
     }
 
     purchaseDataLayerObject.ecommerce.items = items;
 
     return purchaseDataLayerObject;
-  }
+  };
   return (
     <div>
       <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
@@ -134,7 +134,7 @@ export function CartMain({ cart: originalCart }: CartMainProps) {
                         name={`quantity-${productIdx}`}
                         className="max-w-full rounded-md border border-gray-300 py-1.5 text-left text-base/5 font-medium text-gray-700 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
                       >
-                        {Array.from({ length: 10 }, (_, i) => i).map((i) => (
+                        {Array.from({length: 10}, (_, i) => i).map((i) => (
                           <option key={i + 1} value={i + 1}>
                             {i + 1}
                           </option>
@@ -267,13 +267,12 @@ export function CartMain({ cart: originalCart }: CartMainProps) {
             <NavLink
               onClick={(e) =>
                 hasCartItems && cart
-                  ? (
-                    window.dataLayer = window.dataLayer || [],
-                    window.dataLayer.push({ ecommerce: null }),
+                  ? ((window.dataLayer = window.dataLayer || []),
+                    window.dataLayer.push({ecommerce: null}),
                     window.dataLayer.push(buildDataLayerForPurchase(cart)),
                     coveoCart.methods?.purchase({
                       id: cart?.id || '',
-                      revenue: Number(cart?.cost?.totalAmount?.amount)
+                      revenue: Number(cart?.cost?.totalAmount?.amount),
                     }))
                   : e.preventDefault()
               }

--- a/app/components/Cart/CartMain.tsx
+++ b/app/components/Cart/CartMain.tsx
@@ -7,6 +7,7 @@ import { useCart } from '~/lib/coveo.engine';
 import cx from '~/lib/cx';
 import type { CartLine } from '@shopify/hydrogen/storefront-api-types';
 import { mapShopifyMerchandiseToCoveoCartItem } from '~/lib/map.coveo.shopify';
+import '~/types/gtm';
 
 export type CartLayout = 'page' | 'aside';
 
@@ -267,11 +268,8 @@ export function CartMain({ cart: originalCart }: CartMainProps) {
               onClick={(e) =>
                 hasCartItems && cart
                   ? (
-                    //@ts-ignore
                     window.dataLayer = window.dataLayer || [],
-                    //@ts-ignore
-                    dataLayer.push({ ecommerce: null }),
-                    //@ts-ignore
+                    window.dataLayer.push({ ecommerce: null }),
                     window.dataLayer.push(buildDataLayerForPurchase(cart)),
                     coveoCart.methods?.purchase({
                       id: cart?.id || '',

--- a/app/components/Cart/CartRecommendations.tsx
+++ b/app/components/Cart/CartRecommendations.tsx
@@ -1,47 +1,50 @@
-import { useCartRecommendations } from '~/lib/coveo.engine';
-import { ProductCard } from '../Products/ProductCard';
-import { useEffect } from 'react';
+import {useCartRecommendations} from '~/lib/coveo.engine';
+import {ProductCard} from '../Products/ProductCard';
+import {useEffect} from 'react';
 import '~/types/gtm';
 
 let hasRunRef = false;
 
 type itemsList = {
-  item_id: string,
-  item_name: string,
-  index: number,
-  price: number,
-  quantity: number
-}
+  item_id: string;
+  item_name: string;
+  index: number;
+  price: number;
+  quantity: number;
+};
 
 export function CartRecommendations() {
   const recs = useCartRecommendations();
-
-  const recommendationsItemsArray: itemsList[] = [];
-  recs.state.products.forEach((recommendationItem: any, index: number) => {
-    recommendationsItemsArray.push({
-      item_id: recommendationItem.permanentid,
-      item_name: recommendationItem.ec_name,
-      index: index,
-      price: recommendationItem.ec_price,
-      quantity: 1
-    })
-  });
 
   useEffect(() => {
     if (hasRunRef) return;
     hasRunRef = true;
 
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-    window.dataLayer.push({
-      event: "view_item_list",
-      ecommerce: {
-        item_list_id: `recommendations_${recs.state.headline.toString().replaceAll(' ', '_').toLowerCase()}`,
-        item_list_name: recs.state.headline,
-        items: recommendationsItemsArray
-      }
+    const recommendationsItemsArray: itemsList[] = [];
+    recs.state.products.forEach((recommendationItem: any, index: number) => {
+      recommendationsItemsArray.push({
+        item_id: recommendationItem.permanentid,
+        item_name: recommendationItem.ec_name,
+        index,
+        price: recommendationItem.ec_price,
+        quantity: 1,
+      });
     });
-  }, []);
+
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ecommerce: null}); // Clear the previous ecommerce object.
+    window.dataLayer.push({
+      event: 'view_item_list',
+      ecommerce: {
+        item_list_id: `recommendations_${recs.state.headline
+          .toString()
+          .replaceAll(' ', '_')
+          .toLowerCase()}`,
+        item_list_name: recs.state.headline,
+        items: recommendationsItemsArray,
+      },
+    });
+  }, [recs.state.headline, recs.state.products]);
 
   return (
     <section
@@ -61,7 +64,7 @@ export function CartRecommendations() {
             className="recommendation-card"
             onSelect={
               recs.methods?.interactiveProduct({
-                options: { product: relatedProduct },
+                options: {product: relatedProduct},
               }).select
             }
             product={relatedProduct}

--- a/app/components/Cart/CartRecommendations.tsx
+++ b/app/components/Cart/CartRecommendations.tsx
@@ -1,10 +1,8 @@
 import {useCartRecommendations} from '~/lib/coveo.engine';
 import {ProductCard} from '../Products/ProductCard';
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import type {Product} from '@coveo/headless-react/ssr-commerce';
 import '~/types/gtm';
-
-let hasRunRef = false;
 
 type itemsList = {
   item_id: string;
@@ -32,11 +30,12 @@ interface RecommendationController {
 }
 
 export function CartRecommendations() {
+  const hasRunRef = useRef(false);
   const recs = useCartRecommendations() as RecommendationController;
 
   useEffect(() => {
-    if (hasRunRef) return;
-    hasRunRef = true;
+    if (hasRunRef.current) return;
+    hasRunRef.current = true;
 
     const recommendationsItemsArray: itemsList[] = [];
     recs.state.products.forEach(

--- a/app/components/Cart/CartRecommendations.tsx
+++ b/app/components/Cart/CartRecommendations.tsx
@@ -1,6 +1,7 @@
 import { useCartRecommendations } from '~/lib/coveo.engine';
 import { ProductCard } from '../Products/ProductCard';
 import { useEffect } from 'react';
+import '~/types/gtm';
 
 let hasRunRef = false;
 
@@ -30,11 +31,8 @@ export function CartRecommendations() {
     if (hasRunRef) return;
     hasRunRef = true;
 
-    //@ts-ignore
     window.dataLayer = window.dataLayer || [];
-    //@ts-ignore
     window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-    //@ts-ignore
     window.dataLayer.push({
       event: "view_item_list",
       ecommerce: {

--- a/app/components/Homepage/Recommendations.tsx
+++ b/app/components/Homepage/Recommendations.tsx
@@ -88,21 +88,29 @@ export function Recommendations() {
 
         <div className="recommendation-list mt-6 grid grid-cols-1 gap-y-10 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-0 lg:gap-x-8">
           {homepageRecommendations.state.products.map(
-            (recommendation: Product) => (
-              <div key={recommendation.permanentid} className="group relative">
-                <ProductCard
-                  className="recommendation-card"
-                  product={recommendation}
-                  onSelect={() =>
-                    homepageRecommendations.methods
-                      ?.interactiveProduct({
-                        options: {product: recommendation},
-                      })
-                      .select()
-                  }
-                />
-              </div>
-            ),
+            (recommendation: Product) => {
+              // Exclude children to prevent color swatches on recs carousel
+              const {children, ...productWithoutEcColor} = recommendation;
+
+              return (
+                <div
+                  key={recommendation.permanentid}
+                  className="group relative"
+                >
+                  <ProductCard
+                    className="recommendation-card"
+                    product={productWithoutEcColor as Product}
+                    onSelect={() =>
+                      homepageRecommendations.methods
+                        ?.interactiveProduct({
+                          options: {product: productWithoutEcColor as Product},
+                        })
+                        .select()
+                    }
+                  />
+                </div>
+              );
+            },
           )}
         </div>
       </div>

--- a/app/components/Homepage/Recommendations.tsx
+++ b/app/components/Homepage/Recommendations.tsx
@@ -1,46 +1,56 @@
-import { useHomepageRecommendations } from '~/lib/coveo.engine';
-import { ProductCard } from '../Products/ProductCard';
-import { useEffect, useRef } from 'react';
+import {useHomepageRecommendations} from '~/lib/coveo.engine';
+import {ProductCard} from '../Products/ProductCard';
+import {useEffect, useRef} from 'react';
 import '~/types/gtm';
 
+// Global tracking to ensure analytics only fire once
 let hasRunRef = false;
 
 type itemsList = {
-  item_id: string,
-  item_name: string,
-  index: number,
-  price: number,
-  quantity: number
-}
+  item_id: string;
+  item_name: string;
+  index: number;
+  price: number;
+  quantity: number;
+};
 
 export function Recommendations() {
   const homepageRecommendations = useHomepageRecommendations();
 
-  const recommendationsItemsArray: itemsList[] = [];
-  homepageRecommendations.state.products.forEach((recommendationItem: any, index: number) => {
-    recommendationsItemsArray.push({
-      item_id: recommendationItem.permanentid,
-      item_name: recommendationItem.ec_name,
-      index: index,
-      price: recommendationItem.ec_price,
-      quantity: 1
-    })
-  });
-
   useEffect(() => {
     if (hasRunRef) return;
     hasRunRef = true;
+
+    const recommendationsItemsArray: itemsList[] = [];
+    homepageRecommendations.state.products.forEach(
+      (recommendationItem: any, index: number) => {
+        recommendationsItemsArray.push({
+          item_id: recommendationItem.permanentid,
+          item_name: recommendationItem.ec_name,
+          index,
+          price: recommendationItem.ec_price,
+          quantity: 1,
+        });
+      },
+    );
+
     window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+    window.dataLayer.push({ecommerce: null}); // Clear the previous ecommerce object.
     window.dataLayer.push({
-      event: "view_item_list",
+      event: 'view_item_list',
       ecommerce: {
-        item_list_id: `recommendations_${homepageRecommendations.state.headline.toString().replaceAll(' ', '_').toLowerCase()}`,
+        item_list_id: `recommendations_${homepageRecommendations.state.headline
+          .toString()
+          .replaceAll(' ', '_')
+          .toLowerCase()}`,
         item_list_name: homepageRecommendations.state.headline,
-        items: recommendationsItemsArray
-      }
+        items: recommendationsItemsArray,
+      },
     });
-  }, []);
+  }, [
+    homepageRecommendations.state.products,
+    homepageRecommendations.state.headline,
+  ]);
 
   return (
     <section
@@ -65,13 +75,12 @@ export function Recommendations() {
                 product={recommendation}
                 onSelect={
                   homepageRecommendations.methods?.interactiveProduct({
-                    options: { product: recommendation },
+                    options: {product: recommendation},
                   }).select
                 }
               />
             </div>
-          ))
-          }
+          ))}
         </div>
       </div>
     </section>

--- a/app/components/Homepage/Recommendations.tsx
+++ b/app/components/Homepage/Recommendations.tsx
@@ -1,6 +1,7 @@
 import { useHomepageRecommendations } from '~/lib/coveo.engine';
 import { ProductCard } from '../Products/ProductCard';
 import { useEffect, useRef } from 'react';
+import '~/types/gtm';
 
 let hasRunRef = false;
 
@@ -29,11 +30,8 @@ export function Recommendations() {
   useEffect(() => {
     if (hasRunRef) return;
     hasRunRef = true;
-    //@ts-ignore
     window.dataLayer = window.dataLayer || [];
-    //@ts-ignore
     window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-    //@ts-ignore
     window.dataLayer.push({
       event: "view_item_list",
       ecommerce: {

--- a/app/components/Products/ProductCard.tsx
+++ b/app/components/Products/ProductCard.tsx
@@ -26,11 +26,15 @@ export function ProductCard({
   const [selectedColor, setSelectedColor] = useState(
     product.ec_color || 'Black',
   );
-  const availableColors = product.children?.map((c) => c.ec_color || '') || [];
+  const availableColors = Array.from(
+    new Set(product.children?.map((c) => c.ec_color || '') || []),
+  );
   const productImage =
     product.children?.find((c) => c.ec_color === selectedColor)?.ec_images[0] ||
     product.ec_images[0];
-  const productId = product.ec_item_group_id;
+  const productLink = new URL(product.clickUri).pathname;
+  const productName = (product.additionalFields?.ec_item_group_name ||
+    '') as string;
 
   const onColorChange = (color: string) => {
     setSelectedColor(color);
@@ -42,19 +46,19 @@ export function ProductCard({
       <NavLink
         key={product.permanentid}
         onClick={onSelect}
-        to={`/products/${productId?.toUpperCase()}?Color=${selectedColor}`}
+        to={`${productLink}?Color=${selectedColor}`}
         className={`${className} group`}
       >
         <img
           loading="lazy"
           width={1024}
           height={1024}
-          alt={product.ec_name!}
+          alt={productName}
           src={productImage}
           className="aspect-square w-full rounded-lg bg-gray-200 object-cover group-hover:opacity-75"
         />
         <h3 className="result-title mt-4 text-sm text-gray-700">
-          {product.ec_name}
+          {productName}
         </h3>
         <div className="flex">
           {Array.from(Array(5).keys()).map((i) => {

--- a/app/components/Products/Recommendations.tsx
+++ b/app/components/Products/Recommendations.tsx
@@ -4,6 +4,7 @@ import {
 } from '~/lib/coveo.engine';
 import { ProductCard } from './ProductCard';
 import { Fragment, useEffect } from 'react';
+import '~/types/gtm';
 
 let hasRunRefUpper = false;
 let hasRunRefLower = false;
@@ -45,20 +46,14 @@ export function ProductRecommendations() {
 
     if (hasRunRefUpper) return;
     hasRunRefUpper = true;
-    //@ts-ignore
     window.dataLayer = window.dataLayer || [];
-    //@ts-ignore
     window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-    //@ts-ignore
     window.dataLayer.push(constructViewItemsListEvent(pdpRecommendationsUpperCarousel));
 
     if (hasRunRefLower) return;
     hasRunRefLower = true;
-    //@ts-ignore
     window.dataLayer = window.dataLayer || [];
-    //@ts-ignore
     window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-    //@ts-ignore
     window.dataLayer.push(constructViewItemsListEvent(pdpRecommendationsLowerCarousel));
 
   }, []);

--- a/app/components/Products/Recommendations.tsx
+++ b/app/components/Products/Recommendations.tsx
@@ -2,19 +2,19 @@ import {
   usePdpRecommendationsLowerCarousel,
   usePdpRecommendationsUpperCarousel,
 } from '~/lib/coveo.engine';
-import { ProductCard } from './ProductCard';
-import { Fragment, useEffect } from 'react';
+import {ProductCard} from './ProductCard';
+import {Fragment, useEffect} from 'react';
 import '~/types/gtm';
 
 let hasRunRefUpper = false;
 let hasRunRefLower = false;
 
 type itemsList = {
-  item_id: string,
-  item_name: string,
-  index: number,
-  price: number,
-  quantity: number
+  item_id: string;
+  item_name: string;
+  index: number;
+  price: number;
+  quantity: number;
 };
 
 export function ProductRecommendations() {
@@ -23,40 +23,47 @@ export function ProductRecommendations() {
 
   function constructViewItemsListEvent(recommendationsProducts: any) {
     const recommandationsItemsArray: itemsList[] = [];
-    recommendationsProducts.state.products.slice(0, 4).forEach((recommendationItem: any, index: number) => {
-      recommandationsItemsArray.push({
-        item_id: recommendationItem.permanentid,
-        item_name: recommendationItem.ec_name,
-        index: index,
-        price: recommendationItem.ec_price,
-        quantity: 1
-      })
-    });
+    recommendationsProducts.state.products
+      .slice(0, 4)
+      .forEach((recommendationItem: any, index: number) => {
+        recommandationsItemsArray.push({
+          item_id: recommendationItem.permanentid,
+          item_name: recommendationItem.ec_name,
+          index,
+          price: recommendationItem.ec_price,
+          quantity: 1,
+        });
+      });
     return {
-      event: "view_item_list",
+      event: 'view_item_list',
       ecommerce: {
-        item_list_id: `recommendations_${recommendationsProducts.state.headline.toString().replaceAll(' ', '_').toLowerCase()}`,
+        item_list_id: `recommendations_${recommendationsProducts.state.headline
+          .toString()
+          .replaceAll(' ', '_')
+          .toLowerCase()}`,
         item_list_name: recommendationsProducts.state.headline,
-        items: recommandationsItemsArray
-      }
-    }
+        items: recommandationsItemsArray,
+      },
+    };
   }
 
   useEffect(() => {
-
     if (hasRunRefUpper) return;
     hasRunRefUpper = true;
     window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-    window.dataLayer.push(constructViewItemsListEvent(pdpRecommendationsUpperCarousel));
+    window.dataLayer.push({ecommerce: null}); // Clear the previous ecommerce object.
+    window.dataLayer.push(
+      constructViewItemsListEvent(pdpRecommendationsUpperCarousel),
+    );
 
     if (hasRunRefLower) return;
     hasRunRefLower = true;
     window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-    window.dataLayer.push(constructViewItemsListEvent(pdpRecommendationsLowerCarousel));
-
-  }, []);
+    window.dataLayer.push({ecommerce: null}); // Clear the previous ecommerce object.
+    window.dataLayer.push(
+      constructViewItemsListEvent(pdpRecommendationsLowerCarousel),
+    );
+  }, [pdpRecommendationsUpperCarousel, pdpRecommendationsLowerCarousel]);
 
   return (
     <section aria-labelledby="related-heading" className="mt-24">
@@ -86,7 +93,7 @@ export function ProductRecommendations() {
                         key={relatedProduct.permanentid}
                         onSelect={
                           recommendationCarousel.methods?.interactiveProduct({
-                            options: { product: relatedProduct },
+                            options: {product: relatedProduct},
                           }).select
                         }
                       />

--- a/app/components/Search/ProductList.tsx
+++ b/app/components/Search/ProductList.tsx
@@ -6,7 +6,7 @@ import type {
   ProductListState,
   ProductList as ProductListType,
 } from '@coveo/headless/ssr-commerce';
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
 import '~/types/gtm';
 
 // Global tracking to ensure analytics only fire once per response
@@ -49,7 +49,7 @@ export function ProductList() {
 
     const listingsItemsArray: any[] = [];
     productList.state.products.forEach(
-      (recommendationItem: any, index: number) => {
+      (recommendationItem: Product, index: number) => {
         listingsItemsArray.push({
           item_id: recommendationItem.permanentid,
           item_name: recommendationItem.ec_name,

--- a/app/components/Search/ProductList.tsx
+++ b/app/components/Search/ProductList.tsx
@@ -38,12 +38,12 @@ export function ProductList() {
 
   useEffect(() => {
     const responseId = productList.state.responseId;
-    
+
     // Check if we've already tracked this response
     if (!responseId || trackedResponseIds.has(responseId)) {
       return;
     }
-    
+
     // Mark this response as tracked
     trackedResponseIds.add(responseId);
 

--- a/app/components/Search/ProductList.tsx
+++ b/app/components/Search/ProductList.tsx
@@ -4,6 +4,7 @@ import type {
   SearchSummaryState,
   Product,
   ProductListState,
+  ProductList as ProductListType,
 } from '@coveo/headless/ssr-commerce';
 import {useEffect, useRef} from 'react';
 
@@ -11,11 +12,13 @@ export function ProductList() {
   const hasRunRef = useRef(false);
   const productList = engineDefinition.controllers.useProductList() as {
     state: ProductListState;
-    methods: any;
+    methods: Pick<
+      ProductListType,
+      'interactiveProduct' | 'promoteChildToParent'
+    >;
   };
   const summary = engineDefinition.controllers.useSummary() as {
     state: SearchSummaryState;
-    methods: any;
   };
   const noResultClass = !productList.state.products.length
     ? ' no-results '
@@ -26,7 +29,7 @@ export function ProductList() {
     if (child) {
       // TODO: https://coveord.atlassian.net/browse/KIT-3810
       // workaround to promote child to parent
-      (productList.methods as any)?.['promoteChildToParent'](child);
+      productList.methods?.promoteChildToParent(child);
     }
   };
 

--- a/app/components/Search/ProductList.tsx
+++ b/app/components/Search/ProductList.tsx
@@ -7,6 +7,7 @@ import type {
   ProductList as ProductListType,
 } from '@coveo/headless/ssr-commerce';
 import {useEffect, useRef} from 'react';
+import '~/types/gtm';
 
 export function ProductList() {
   const hasRunRef = useRef(false);
@@ -50,11 +51,8 @@ export function ProductList() {
       },
     );
 
-    //@ts-ignore
     window.dataLayer = window.dataLayer || [];
-    //@ts-ignore
     window.dataLayer.push({ecommerce: null}); // Clear the previous ecommerce object.
-    //@ts-ignore
     window.dataLayer.push({
       event: 'view_item_list',
       ecommerce: {

--- a/app/components/Search/StandaloneSearchBox.tsx
+++ b/app/components/Search/StandaloneSearchBox.tsx
@@ -13,6 +13,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { ProductCard } from '../Products/ProductCard';
 import { useNavigate } from '@remix-run/react';
+import '~/types/gtm';
 
 const redirectToGenerative = [
   'what',
@@ -51,9 +52,7 @@ export function StandaloneSearchBox({ close }: StandaloneSearchBoxProps) {
       close?.();
     } else {
       searchBox.methods?.submit();
-      //@ts-ignore
       window.dataLayer = window.dataLayer || [];
-      //@ts-ignore
       window.dataLayer.push({
         event: 'search',
         search_type: 'search_box',

--- a/app/components/Search/StandaloneSearchBox.tsx
+++ b/app/components/Search/StandaloneSearchBox.tsx
@@ -5,14 +5,14 @@ import {
   ComboboxOption,
   ComboboxOptions,
 } from '@headlessui/react';
-import { type RefObject, useEffect, useRef } from 'react';
-import { useInstantProducts, useStandaloneSearchBox } from '~/lib/coveo.engine';
+import {type RefObject, useEffect, useRef} from 'react';
+import {useInstantProducts, useStandaloneSearchBox} from '~/lib/coveo.engine';
 import {
   MagnifyingGlassIcon,
   ChatBubbleBottomCenterIcon,
 } from '@heroicons/react/24/outline';
-import { ProductCard } from '../Products/ProductCard';
-import { useNavigate } from '@remix-run/react';
+import {ProductCard} from '../Products/ProductCard';
+import {useNavigate} from '@remix-run/react';
 import '~/types/gtm';
 
 const redirectToGenerative = [
@@ -37,7 +37,7 @@ const shouldRedirectToGenerative = (query: string) => {
 interface StandaloneSearchBoxProps {
   close?: () => void;
 }
-export function StandaloneSearchBox({ close }: StandaloneSearchBoxProps) {
+export function StandaloneSearchBox({close}: StandaloneSearchBoxProps) {
   const searchBox = useStandaloneSearchBox();
   const instantProducts = useInstantProducts();
   const navigate = useNavigate();
@@ -56,7 +56,7 @@ export function StandaloneSearchBox({ close }: StandaloneSearchBoxProps) {
       window.dataLayer.push({
         event: 'search',
         search_type: 'search_box',
-        search_term: encodeURIComponent(searchBox.state.value)
+        search_term: encodeURIComponent(searchBox.state.value),
       });
     }
   };
@@ -140,7 +140,7 @@ export function StandaloneSearchBox({ close }: StandaloneSearchBoxProps) {
                         className="product-suggestion"
                         onSelect={
                           instantProducts.methods?.interactiveProduct({
-                            options: { product },
+                            options: {product},
                           }).select
                         }
                       />
@@ -170,10 +170,11 @@ function useRedirect(
 
   useEffect(() => {
     if (searchBox.state.redirectTo === '/search') {
-      const url = `${shouldRedirectToGenerative(searchBox.state.value)
-        ? '/generative'
-        : searchBox.state.redirectTo
-        }?q=${encodeURIComponent(searchBox.state.value)}`;
+      const url = `${
+        shouldRedirectToGenerative(searchBox.state.value)
+          ? '/generative'
+          : searchBox.state.redirectTo
+      }?q=${encodeURIComponent(searchBox.state.value)}`;
 
       navigate(url);
       close?.();

--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -70,16 +70,16 @@ export const engineConfig: CommerceEngineDefinitionOptions = {
     facetGenerator: defineFacetGenerator(),
     breadcrumbManager: defineBreadcrumbManager(),
     homepageRecommendations: defineRecommendations({
-      options: {slotId: '9a75d3ba-c053-40bf-b881-6d2d3f8472db'},
+      options: {slotId: '046e2c92-63a5-47dd-8266-b8e5027ae031'},
     }),
     cartRecommendations: defineRecommendations({
-      options: {slotId: '5a93e231-3b58-4dd2-a00b-667e4fd62c55'},
+      options: {slotId: 'b236b1e2-f9b1-4f5d-b384-c1872f6d0b37'},
     }),
     pdpRecommendationsLowerCarousel: defineRecommendations({
-      options: {slotId: 'a24b0e9c-a8d2-4d4f-be76-5962160504e2'},
+      options: {slotId: '43b896c6-57a6-4eb0-a511-69eb7b35f7e3'},
     }),
     pdpRecommendationsUpperCarousel: defineRecommendations({
-      options: {slotId: '05848244-5c01-4846-b280-ff63f5530733'},
+      options: {slotId: '68f1384f-b27c-4355-ac9a-7b63ba084e71'},
     }),
     parameterManager: defineParameterManager(),
   },

--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -3,8 +3,6 @@ import {
   defineFacetGenerator,
   definePagination,
   defineProductList,
-  type InferHydratedState,
-  type InferStaticState,
   defineSummary,
   defineCart,
   defineSort,
@@ -17,6 +15,9 @@ import {
   defineBreadcrumbManager,
   defineParameterManager,
   defineRecommendations,
+  type InferHydratedState,
+  type InferStaticState,
+  type CommerceEngineDefinitionOptions,
 } from '@coveo/headless-react/ssr-commerce';
 import {fetchToken} from './fetch-token';
 

--- a/app/lib/coveo.engine.ts
+++ b/app/lib/coveo.engine.ts
@@ -40,7 +40,7 @@ export const engineConfig: CommerceEngineDefinitionOptions = {
     organizationId: 'barcagroupproductionkwvdy6lp',
     analytics: {
       enabled: true,
-      trackingId: 'shop_en_us',
+      trackingId: 'market_88728731922',
     },
     context: {
       language: 'en',

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -139,7 +139,7 @@ async function loadCriticalData({ context, request }: LoaderFunctionArgs) {
     storefront.query(HEADER_QUERY, {
       cache: storefront.CacheLong(),
       variables: {
-        headerMenuHandle: 'hydrogen-menu',
+        headerMenuHandle: 'coveo-shopify-menu',
       },
     }),
     loggedIn

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,5 +1,5 @@
-import { useNonce, getShopAnalytics, Analytics, Script } from '@shopify/hydrogen';
-import { defer, type LoaderFunctionArgs } from '@shopify/remix-oxygen';
+import {useNonce, getShopAnalytics, Analytics, Script} from '@shopify/hydrogen';
+import {defer, type LoaderFunctionArgs} from '@shopify/remix-oxygen';
 import {
   Links,
   Meta,
@@ -13,18 +13,18 @@ import {
 } from '@remix-run/react';
 import favicon from '~/assets/favicon.ico';
 import tailwindCss from './styles/tailwind.css?url';
-import { PageLayout } from '~/components/PageLayout';
-import { FOOTER_QUERY, GET_CUSTOMER_QUERY, HEADER_QUERY } from '~/lib/fragments';
-import { engineDefinition } from './lib/coveo.engine';
-import { fetchStaticState } from './lib/coveo.engine.server';
+import {PageLayout} from '~/components/PageLayout';
+import {FOOTER_QUERY, GET_CUSTOMER_QUERY, HEADER_QUERY} from '~/lib/fragments';
+import {engineDefinition} from './lib/coveo.engine';
+import {fetchStaticState} from './lib/coveo.engine.server';
 import {
   ClientSideNavigatorContextProvider,
   ServerSideNavigatorContextProvider,
 } from './lib/navigator.provider';
-import { StandaloneProvider } from './components/Search/Context';
-import { GlobalLoading } from './components/ProgressBar';
-import { getLocaleFromRequest } from './lib/i18n';
-import { getCookieFromRequest } from './lib/session';
+import {StandaloneProvider} from './components/Search/Context';
+import {GlobalLoading} from './components/ProgressBar';
+import {getLocaleFromRequest} from './lib/i18n';
+import {getCookieFromRequest} from './lib/session';
 export type RootLoader = typeof loader;
 
 /**
@@ -47,7 +47,7 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 
 export function links() {
   return [
-    { rel: 'stylesheet', href: tailwindCss },
+    {rel: 'stylesheet', href: tailwindCss},
     {
       rel: 'preconnect',
       href: 'https://cdn.shopify.com',
@@ -56,7 +56,7 @@ export function links() {
       rel: 'preconnect',
       href: 'https://shop.app',
     },
-    { rel: 'icon', type: 'image/svg+xml', href: favicon },
+    {rel: 'icon', type: 'image/svg+xml', href: favicon},
   ];
 }
 
@@ -67,9 +67,9 @@ export async function loader(args: LoaderFunctionArgs) {
   // Await the critical data required to render initial state of the page
   const criticalData = await loadCriticalData(args);
 
-  const { storefront, env } = args.context;
+  const {storefront, env} = args.context;
 
-  const { country, currency, language } = getLocaleFromRequest(args.request);
+  const {country, currency, language} = getLocaleFromRequest(args.request);
 
   args.context.customerAccount.UNSTABLE_getBuyer().then((buyer) => {
     args.context.cart.updateBuyerIdentity({
@@ -108,8 +108,8 @@ export async function loader(args: LoaderFunctionArgs) {
       headers: alreadyHasCookie
         ? {}
         : {
-          'Set-Cookie': criticalData.coveoVisitorIdHeader,
-        },
+            'Set-Cookie': criticalData.coveoVisitorIdHeader,
+          },
     },
   );
 }
@@ -118,8 +118,8 @@ export async function loader(args: LoaderFunctionArgs) {
  * Load data necessary for rendering content above the fold. This is the critical data
  * needed to render the page. If it's unavailable, the whole page should 400 or 500 error.
  */
-async function loadCriticalData({ context, request }: LoaderFunctionArgs) {
-  const { storefront, customerAccount, cart } = context;
+async function loadCriticalData({context, request}: LoaderFunctionArgs) {
+  const {storefront, customerAccount, cart} = context;
 
   const loggedIn = await customerAccount.isLoggedIn();
 
@@ -144,11 +144,11 @@ async function loadCriticalData({ context, request }: LoaderFunctionArgs) {
     }),
     loggedIn
       ? context.customerAccount.query<{
-        customer: {
-          firstName: string;
-          imageUrl: string;
-        };
-      }>(GET_CUSTOMER_QUERY)
+          customer: {
+            firstName: string;
+            imageUrl: string;
+          };
+        }>(GET_CUSTOMER_QUERY)
       : null,
     fetchStaticState({
       context,
@@ -174,8 +174,8 @@ async function loadCriticalData({ context, request }: LoaderFunctionArgs) {
  * fetched after the initial page load. If it's unavailable, the page should still 200.
  * Make sure to not throw any errors here, as it will cause the page to 500.
  */
-function loadDeferredData({ context }: LoaderFunctionArgs) {
-  const { storefront, cart } = context;
+function loadDeferredData({context}: LoaderFunctionArgs) {
+  const {storefront, cart} = context;
 
   // defer the footer query (below the fold)
   const footer = storefront
@@ -197,7 +197,7 @@ function loadDeferredData({ context }: LoaderFunctionArgs) {
   };
 }
 
-export function Layout({ children }: { children?: React.ReactNode }) {
+export function Layout({children}: {children?: React.ReactNode}) {
   const nonce = useNonce();
   const data = useRouteLoaderData<RootLoader>('root');
 
@@ -208,10 +208,7 @@ export function Layout({ children }: { children?: React.ReactNode }) {
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
-        <Script
-          waitForHydration
-          src="/scripts/google-tag-manager.js"
-        />
+        <Script waitForHydration src="/scripts/google-tag-manager.js" />
       </head>
       <body>
         {data ? (

--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -26,7 +26,7 @@ export async function loader({request, context}: LoaderFunctionArgs) {
     context.storefront.query(HEADER_QUERY, {
       cache: context.storefront.CacheLong(),
       variables: {
-        headerMenuHandle: 'hydrogen-menu',
+        headerMenuHandle: 'coveo-shopify-menu',
       },
     }),
     fetchRecommendationStaticState({

--- a/app/routes/($locale).generative.tsx
+++ b/app/routes/($locale).generative.tsx
@@ -16,6 +16,7 @@ import { AnswerSection } from '~/components/Generative/Section';
 import { Skeleton } from '~/components/Generative/Skeleton';
 import { Answer } from '~/components/Generative/Answer';
 import type { AnswerToProductsData } from './answer-to-products';
+import '~/types/gtm';
 
 /**
 What to look for when buying a kayak?
@@ -47,9 +48,7 @@ export default function GenerativeAnswering() {
     genAnswerState?.citations && genAnswerState.citations.length > 0;
 
   const trackGenerativeAnswering = (hasNoAnswer: any) => {
-    //@ts-ignore
     window.dataLayer = window.dataLayer || [];
-    //@ts-ignore
     window.dataLayer.push({
       event: "search",
       search_type: "generative_answering",

--- a/app/routes/($locale).generative.tsx
+++ b/app/routes/($locale).generative.tsx
@@ -172,7 +172,7 @@ export default function GenerativeAnswering() {
                                 width={200}
                                 height={200}
                                 alt={product.title}
-                                src={(product.raw['ec_images'] as string[])[0]}
+                                src={product.raw['ec_images'] as string}
                                 className="h-48 w-48 rounded-lg bg-gray-200 object-cover group-hover:opacity-75"
                               />
                             </NavLink>

--- a/app/routes/($locale).generative.tsx
+++ b/app/routes/($locale).generative.tsx
@@ -5,17 +5,17 @@ import {
   type GeneratedAnswerState,
   type Result,
 } from '@coveo/headless';
-import { NavLink, useFetcher, useLoaderData } from '@remix-run/react';
-import { useEffect, useState } from 'react';
-import { type LoaderFunctionArgs } from '@shopify/remix-oxygen';
-import { BookOpenIcon } from '@heroicons/react/24/outline';
+import {NavLink, useFetcher, useLoaderData} from '@remix-run/react';
+import {useEffect, useState} from 'react';
+import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
+import {BookOpenIcon} from '@heroicons/react/24/outline';
 import cx from '~/lib/cx';
-import type { AnswerToArticlesData } from './answer-to-articles';
-import { ResultCard } from '~/components/Generative/ResultCard';
-import { AnswerSection } from '~/components/Generative/Section';
-import { Skeleton } from '~/components/Generative/Skeleton';
-import { Answer } from '~/components/Generative/Answer';
-import type { AnswerToProductsData } from './answer-to-products';
+import type {AnswerToArticlesData} from './answer-to-articles';
+import {ResultCard} from '~/components/Generative/ResultCard';
+import {AnswerSection} from '~/components/Generative/Section';
+import {Skeleton} from '~/components/Generative/Skeleton';
+import {Answer} from '~/components/Generative/Answer';
+import type {AnswerToProductsData} from './answer-to-products';
 import '~/types/gtm';
 
 // Global tracking to ensure analytics only fire once per search query
@@ -40,16 +40,16 @@ Which kayak materials offer the best balance for advanced use?
 
  */
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({request}: LoaderFunctionArgs) {
   const url = new URL(request.url);
   const q = url.searchParams.get('q') || '';
-  return { q };
+  return {q};
 }
 
 export default function GenerativeAnswering() {
-  const { q } = useLoaderData<typeof loader>();
+  const {q} = useLoaderData<typeof loader>();
   const genAnswerState = useGenAIAnswer(q);
-  const { relatedArticles, basicExpression } = useRelatedArticles(
+  const {relatedArticles, basicExpression} = useRelatedArticles(
     q,
     genAnswerState,
   );
@@ -215,7 +215,7 @@ export default function GenerativeAnswering() {
 }
 
 function useGenAIAnswer(q: string) {
-  const { gen, searchBox } = initGenAI();
+  const {gen, searchBox} = initGenAI();
   const [genAnswerState, setGenAnswerState] = useState<GeneratedAnswerState>();
 
   useEffect(() => {
@@ -243,13 +243,13 @@ function initGenAI() {
 
   const gen = buildGeneratedAnswer(searchEngine, {
     initialState: {
-      responseFormat: { contentFormat: ['text/markdown'] },
+      responseFormat: {contentFormat: ['text/markdown']},
       isEnabled: true,
       isVisible: true,
     },
   });
   const searchBox = buildSearchBox(searchEngine);
-  return { gen, searchBox };
+  return {gen, searchBox};
 }
 
 function useRelatedArticles(q: string, genAnswerState?: GeneratedAnswerState) {
@@ -281,7 +281,7 @@ function useRelatedArticles(q: string, genAnswerState?: GeneratedAnswerState) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [genAnswerState]);
 
-  return { relatedArticles, basicExpression };
+  return {relatedArticles, basicExpression};
 }
 
 function useHasNoAnswerAfterADelay(

--- a/app/routes/($locale).generative.tsx
+++ b/app/routes/($locale).generative.tsx
@@ -18,6 +18,19 @@ import { Answer } from '~/components/Generative/Answer';
 import type { AnswerToProductsData } from './answer-to-products';
 import '~/types/gtm';
 
+// Global tracking to ensure analytics only fire once per search query
+const trackedSearchQueries = new Set<string>();
+
+const trackGenerativeAnswering = (q: string, hasNoAnswer: boolean) => {
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    event: 'search',
+    search_type: 'generative_answering',
+    search_term: q,
+    has_answer: hasNoAnswer ? 'false' : 'true',
+  });
+};
+
 /**
 What to look for when buying a kayak?
 What accessories do I need for a kayak adventure?
@@ -47,19 +60,22 @@ export default function GenerativeAnswering() {
   const hasCitations =
     genAnswerState?.citations && genAnswerState.citations.length > 0;
 
-  const trackGenerativeAnswering = (hasNoAnswer: any) => {
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({
-      event: "search",
-      search_type: "generative_answering",
-      search_term: q,
-      has_answer: hasNoAnswer ? "false" : "true"
-    });
-  }
-
   useEffect(() => {
-    trackGenerativeAnswering(hasNoAnswerAfterADelay)
-  }, [hasNoAnswerAfterADelay]);
+    // Create a unique tracking ID based on the query and answer status
+    const trackingId = `search_${q}_${
+      hasNoAnswerAfterADelay ? 'no_answer' : 'has_answer'
+    }`;
+
+    // Check if we've already tracked this specific search
+    if (trackedSearchQueries.has(trackingId)) {
+      return;
+    }
+
+    // Mark this search as tracked
+    trackedSearchQueries.add(trackingId);
+
+    trackGenerativeAnswering(q, hasNoAnswerAfterADelay);
+  }, [hasNoAnswerAfterADelay, q]);
 
   return (
     <div className="bg-gray-50">

--- a/app/routes/answer-to-products.tsx
+++ b/app/routes/answer-to-products.tsx
@@ -19,7 +19,7 @@ export async function action({request}: ActionFunctionArgs) {
       },
       body: JSON.stringify({
         q: basicExpression,
-        pipeline: 'cmh-search-shop_en_us-RGA-Products',
+        pipeline: 'cmh-search-shop_en_us_new-RGA-Products',
       }),
     });
     return await res.json();

--- a/app/routes/token.tsx
+++ b/app/routes/token.tsx
@@ -27,7 +27,7 @@ export const loader = async ({request, context}: LoaderFunctionArgs) => {
     });
   }
 
-  const newToken = await fetchTokenFromSAPI(context);
+  const newToken = await fetchTokenFromAppProxy();
 
   const parsedToken = JSON.parse(
     decodeBase64Url(newToken.split('.')[1]),

--- a/app/types/gtm.ts
+++ b/app/types/gtm.ts
@@ -1,0 +1,99 @@
+/**
+ * Google Tag Manager DataLayer Types
+ * These interfaces define the structure for Google Analytics 4 Enhanced Ecommerce events
+ */
+
+export interface DataLayerItem {
+  item_id: string;
+  item_name: string;
+  index?: number;
+  price: number;
+  quantity: number;
+}
+
+export interface EcommerceBase {
+  currency?: string;
+  value?: number;
+  items?: DataLayerItem[];
+}
+
+export interface PurchaseEcommerce extends EcommerceBase {
+  transaction_id: string;
+  currency: string;
+  value: number;
+  items: DataLayerItem[];
+}
+
+export interface ViewItemListEcommerce extends EcommerceBase {
+  item_list_id: string;
+  item_list_name?: string;
+  items: DataLayerItem[];
+}
+
+export interface AddToCartEcommerce extends EcommerceBase {
+  currency: string;
+  value: number;
+  items: DataLayerItem[];
+}
+
+export interface RemoveFromCartEcommerce extends EcommerceBase {
+  currency: string;
+  value: number;
+  items: DataLayerItem[];
+}
+
+// Base event interface
+export interface BaseDataLayerEvent {
+  event: string;
+  [key: string]: any;
+}
+
+// Specific event interfaces
+export interface SearchEvent extends BaseDataLayerEvent {
+  event: 'search';
+  search_type: 'search_box' | 'generative_answering';
+  search_term: string;
+  has_answer?: string;
+}
+
+export interface AddToCartEvent extends BaseDataLayerEvent {
+  event: 'add_to_cart';
+  ecommerce: AddToCartEcommerce;
+}
+
+export interface RemoveFromCartEvent extends BaseDataLayerEvent {
+  event: 'remove_from_cart';
+  ecommerce: RemoveFromCartEcommerce;
+}
+
+export interface ViewItemListEvent extends BaseDataLayerEvent {
+  event: 'view_item_list';
+  ecommerce: ViewItemListEcommerce;
+}
+
+export interface PurchaseEvent extends BaseDataLayerEvent {
+  event: 'purchase';
+  ecommerce: PurchaseEcommerce;
+}
+
+// Union type for all possible dataLayer events
+export type DataLayerEvent =
+  | SearchEvent
+  | AddToCartEvent
+  | RemoveFromCartEvent
+  | ViewItemListEvent
+  | PurchaseEvent
+  | {ecommerce: null} // Used to clear previous ecommerce object
+  | BaseDataLayerEvent;
+
+// DataLayer array interface
+export interface DataLayer extends Array<DataLayerEvent> {
+  push(...items: DataLayerEvent[]): number;
+}
+
+// Global window interface extension
+declare global {
+  interface Window {
+    dataLayer: DataLayer;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@shopify/prettier-config": "^1.1.2",
         "@total-typescript/ts-reset": "^0.4.2",
         "@types/eslint": "^8.4.10",
-        "@types/react": "^18.2.22",
+        "@types/react": "^19.1.13",
         "@types/react-dom": "^18.2.7",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.20.0",
@@ -5977,21 +5977,13 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
-      "integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
+      "version": "19.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7610,9 +7610,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001689",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz",
-      "integrity": "sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==",
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8196,16 +8196,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/coveo.analytics/node_modules/@types/react": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.5.tgz",
-      "integrity": "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/coveo.analytics/node_modules/ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@total-typescript/ts-reset": "^0.4.2",
         "@types/eslint": "^8.4.10",
         "@types/react": "^19.1.13",
-        "@types/react-dom": "^18.2.7",
+        "@types/react-dom": "^19.1.9",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.20.0",
         "eslint-plugin-hydrogen": "0.12.3",
@@ -5988,13 +5988,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
+      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@types/semver": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@shopify/prettier-config": "^1.1.2",
     "@total-typescript/ts-reset": "^0.4.2",
     "@types/eslint": "^8.4.10",
-    "@types/react": "^18.2.22",
+    "@types/react": "^19.1.13",
     "@types/react-dom": "^18.2.7",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@total-typescript/ts-reset": "^0.4.2",
     "@types/eslint": "^8.4.10",
     "@types/react": "^19.1.13",
-    "@types/react-dom": "^18.2.7",
+    "@types/react-dom": "^19.1.9",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.20.0",
     "eslint-plugin-hydrogen": "0.12.3",

--- a/public/scripts/google-tag-manager.js
+++ b/public/scripts/google-tag-manager.js
@@ -1,8 +1,13 @@
 (function (w, d, s, l, i) {
-    w[l] = w[l] || []; w[l].push({
-        'gtm.start':
-            new Date().getTime(), event: 'gtm.js'
-    }); var f = d.getElementsByTagName(s)[0],
-        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-            'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+  w[l] = w[l] || [];
+  w[l].push({
+    'gtm.start': new Date().getTime(),
+    event: 'gtm.js',
+  });
+  var f = d.getElementsByTagName(s)[0],
+    j = d.createElement(s),
+    dl = l != 'dataLayer' ? '&l=' + l : '';
+  j.async = true;
+  j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+  f.parentNode.insertBefore(j, f);
 })(window, document, 'script', 'dataLayer', 'GTM-5WL74CPW');


### PR DESCRIPTION
### Switch site from Push source to App (GraphQL) source
- Linked to related [Shop updates](https://github.com/coveo/barca-data/pull/65) in Barca Data  

### Core updates
#### Site Changes
- Shopify Category Taxonomy means changes to product categories and navigation menu
- Product handling on listing pages and recommendations updated due to variant promotion from the Shopify App
- Switched token fetching to `fetchTokenFromAppProxy` (instead of the Search API connection)  

#### Product recommendations
- Added explicit TypeScript interfaces for recommendation controllers  
- Updated components to use these new types  
- Ensured GTM tracking only fires once per recommendation list  

#### Product card & carousel
- Deduplicated color options and used canonical product names/URLs  
- Excluded child products in carousels to avoid duplicate swatches  
- Improved data consistency for display and analytics

### Bonus updates
#### Analytics & GTM improvements
- Replaced all `@ts-ignore` with proper type definitions for GTM events  
- Standardized GTM payloads:
  - Consistent quotes  
  - Cleared old ecommerce data  
  - Normalized add/remove/purchase/view events  

---

**Result:** Cleaner type-safe code, more reliable GTM tracking, and better product recommendation handling.