### PR TITLE
UNI-1357 Fix for 'sold out' on most products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # skeleton
 
+## 2025.12.4
+
+### Patch Changes
+
+- Updated `AddToCartButton` in the `Product` route to simplify the `disabled` logic and replaced the conditional label with a static "Add to cart" text.
+
 ## 2025.10.1
 
 ### Patch Changes

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -235,7 +235,7 @@ export default function Product() {
               <div className="mt-10 flex">
                 <AddToCartButton
                   disabled={
-                    !selectedVariant || !selectedVariant.availableForSale
+                    !selectedVariant
                   }
                   product={product}
                   redirectTo={`/products/${useParams().handle}`}
@@ -251,9 +251,7 @@ export default function Product() {
                       : []
                   }
                 >
-                  {selectedVariant?.availableForSale
-                    ? 'Add to cart'
-                    : 'Sold out'}
+                  Add to cart
                 </AddToCartButton>
                 <button
                   type="button"


### PR DESCRIPTION
Products were showing as sold out because the logic used availableForSale. Since all catalog items have `ec_in_stock = In stock`, I removed that check.
The update to stock field was made in this [PR](https://github.com/coveo/barca-data/pull/67) in barca-data
