### PR TITLE
COMSHOPX-358 Support Product Research Intent

### DIFF
--- a/CONVERSATIONAL_A2UI_RENDERING.md
+++ b/CONVERSATIONAL_A2UI_RENDERING.md
@@ -59,6 +59,7 @@ ACTIVITY_SNAPSHOT event
 - `app/components/Generative/ResponseContent/rendering/component-renderers.tsx`
 - `app/components/Generative/ResponseContent/rendering/render-context.ts`
 - `app/components/Generative/ResponseContent/components/*`
+- `app/lib/generative/product/product-identifier.ts`
 
 ## 4. Event Shape
 
@@ -365,6 +366,7 @@ The actual presentational components live in:
 Important examples:
 
 - `ProductCarousel.tsx`
+- `ProductResearchCard.tsx`
 - `ComparisonTable.tsx`
 - `ComparisonSummary.tsx`
 - `BundleDisplay.tsx`
@@ -393,6 +395,7 @@ That flag is created in `SurfaceRenderer` and passed down through
 The component type still determines the skeleton shape:
 
 - `ProductCarousel` -> carousel skeleton
+- `ProductResearchCard` -> two-column research skeleton
 - `ComparisonTable` -> comparison skeleton
 - `BundleDisplay` -> bundle skeleton
 - `NextActionsBar` -> next-actions skeleton

--- a/app/components/Generative/ResponseContent/components/ProductResearchCard.tsx
+++ b/app/components/Generative/ResponseContent/components/ProductResearchCard.tsx
@@ -140,7 +140,7 @@ export function ProductResearchCard({
                 <SparklesIcon className="h-5 w-5" />
               </div>
               <div className="min-w-0">
-                <h3 className="text-[18px] font-semibold tracking-tight text-slate-900">
+                <h3 className="text-[16px] font-semibold tracking-tight text-slate-900">
                   Product Summary
                 </h3>
                 <p className="text-[12px] text-slate-500">
@@ -154,7 +154,7 @@ export function ProductResearchCard({
 
         {featureBullets.length > 0 ? (
           <section className="px-1 pt-2">
-            <h4 className="text-[18px] font-semibold tracking-tight text-slate-900">
+            <h4 className="text-[16px] font-semibold tracking-tight text-slate-900">
               Key Features
             </h4>
             <ul className="mt-4 space-y-4">

--- a/app/components/Generative/ResponseContent/components/ProductResearchCard.tsx
+++ b/app/components/Generative/ResponseContent/components/ProductResearchCard.tsx
@@ -1,0 +1,176 @@
+import {SparklesIcon} from '@heroicons/react/20/solid';
+import {A2UIProductCard} from './A2UIProductCard';
+import {ProductCardSkeleton} from './Skeletons';
+
+type ProductResearchItem = {
+  clickUri?: string;
+  ec_name?: string | null;
+  ec_description?: string | null;
+  ec_brand?: string | null;
+  ec_category?: string[] | string | null;
+  ec_price?: number | null;
+  ec_promo_price?: number | null;
+  ec_rating?: number | null;
+  ec_product_id?: string | null;
+  ec_image?: string | null;
+  ec_currency?: string | null;
+  ec_colors?: string[] | null;
+  ec_selected_color?: string | null;
+};
+
+interface ProductResearchCardProps {
+  product: ProductResearchItem | null;
+  summary?: string;
+  bullets?: string[];
+  isLoading?: boolean;
+  onProductSelect?: (productId: string) => void;
+}
+
+function getPrimaryCategory(product: ProductResearchItem | null) {
+  if (!product) {
+    return undefined;
+  }
+
+  if (Array.isArray(product.ec_category) && product.ec_category.length > 0) {
+    return product.ec_category[0];
+  }
+
+  return typeof product.ec_category === 'string'
+    ? product.ec_category
+    : undefined;
+}
+
+function ProductResearchCardSkeleton() {
+  return (
+    <div className="grid w-full gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+      <div className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm">
+        <ProductCardSkeleton />
+      </div>
+      <div className="flex flex-col gap-4">
+        <div className="animate-pulse rounded-[24px] border border-indigo-100 bg-indigo-50/70 p-6">
+          <div className="mb-5 flex items-start gap-3">
+            <div className="h-12 w-12 rounded-2xl bg-indigo-200" />
+            <div className="flex-1 space-y-2">
+              <div className="h-5 w-40 rounded bg-indigo-200" />
+              <div className="h-4 w-64 rounded bg-indigo-100" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            <div className="h-4 w-full rounded bg-indigo-100" />
+            <div className="h-4 w-full rounded bg-indigo-100" />
+            <div className="h-4 w-5/6 rounded bg-indigo-100" />
+          </div>
+        </div>
+        <div className="animate-pulse space-y-4 rounded-[24px] border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="h-6 w-36 rounded bg-slate-200" />
+          <div className="space-y-3">
+            {Array.from({length: 5}).map((_, index) => (
+              <div key={index} className="flex items-center gap-3">
+                <div className="h-2.5 w-2.5 rounded-full bg-indigo-300" />
+                <div className="h-4 w-full rounded bg-slate-200" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ProductResearchCard({
+  product,
+  summary,
+  bullets = [],
+  isLoading = false,
+  onProductSelect,
+}: ProductResearchCardProps) {
+  const hasProduct = Boolean(product?.ec_product_id);
+  const hasSummary = Boolean(summary?.trim());
+  const featureBullets = bullets.filter((bullet) => bullet.trim().length > 0);
+
+  if (isLoading && !hasProduct && !hasSummary && featureBullets.length === 0) {
+    return <ProductResearchCardSkeleton />;
+  }
+
+  return (
+    <div className="grid w-full gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+      <div className="w-full lg:max-w-[320px]">
+        {hasProduct && product ? (
+          <div className="rounded-[24px] border border-slate-200 bg-white mt-1 p-4 shadow-sm">
+            <A2UIProductCard
+              productId={product.ec_product_id || ''}
+              name={product.ec_name || ''}
+              brand={product.ec_brand || undefined}
+              imageUrl={product.ec_image || ''}
+              price={Number(product.ec_promo_price ?? product.ec_price) || 0}
+              originalPrice={
+                product.ec_promo_price != null
+                  ? Number(product.ec_price) || undefined
+                  : undefined
+              }
+              currency={product.ec_currency || 'USD'}
+              rating={
+                product.ec_rating != null
+                  ? Number(product.ec_rating)
+                  : undefined
+              }
+              description={product.ec_description || undefined}
+              category={getPrimaryCategory(product)}
+              url={product.clickUri || '#'}
+              colors={product.ec_colors || undefined}
+              selectedColor={product.ec_selected_color || undefined}
+              onSelect={() =>
+                product.ec_product_id &&
+                onProductSelect?.(product.ec_product_id)
+              }
+            />
+          </div>
+        ) : isLoading ? (
+          <div className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm">
+            <ProductCardSkeleton />
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-4">
+        {hasSummary ? (
+          <section className="rounded-[24px] border border-indigo-100 bg-gradient-to-br from-indigo-50 via-indigo-50 to-white mt-1 p-4 shadow-sm">
+            <div className="mb-3 flex items-start gap-3">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-indigo-600 text-white shadow-sm">
+                <SparklesIcon className="h-5 w-5" />
+              </div>
+              <div className="min-w-0">
+                <h3 className="text-[18px] font-semibold tracking-tight text-slate-900">
+                  Product Summary
+                </h3>
+                <p className="text-[12px] text-slate-500">
+                  Generated based on product specs
+                </p>
+              </div>
+            </div>
+            <p className="text-[14px] leading-6 text-slate-700">{summary}</p>
+          </section>
+        ) : null}
+
+        {featureBullets.length > 0 ? (
+          <section className="px-1 pt-2">
+            <h4 className="text-[18px] font-semibold tracking-tight text-slate-900">
+              Key Features
+            </h4>
+            <ul className="mt-4 space-y-4">
+              {featureBullets.map((bullet, index) => (
+                <li
+                  key={`${index}-${bullet}`}
+                  className="flex items-start gap-3 text-[14px] leading-3 text-slate-700"
+                >
+                  <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-indigo-500" />
+                  <span>{bullet}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/components/Generative/ResponseContent/components/ProductResearchCard.tsx
+++ b/app/components/Generative/ResponseContent/components/ProductResearchCard.tsx
@@ -157,13 +157,13 @@ export function ProductResearchCard({
             <h4 className="text-[16px] font-semibold tracking-tight text-slate-900">
               Key Features
             </h4>
-            <ul className="mt-4 space-y-4">
+            <ul className="mt-4 space-y-3">
               {featureBullets.map((bullet, index) => (
                 <li
                   key={`${index}-${bullet}`}
-                  className="flex items-start gap-3 text-[14px] leading-3 text-slate-700"
+                  className="flex items-start gap-3 text-[14px] leading-6 text-slate-700"
                 >
-                  <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-indigo-500" />
+                  <span className="mt-2 h-2 w-2 shrink-0 rounded-full bg-indigo-500" />
                   <span>{bullet}</span>
                 </li>
               ))}

--- a/app/components/Generative/ResponseContent/index.ts
+++ b/app/components/Generative/ResponseContent/index.ts
@@ -2,6 +2,7 @@ export {A2UIProductCard} from './components/A2UIProductCard';
 export {MessageBubble} from './MessageBubble';
 export {Answer} from './components/Answer';
 export {ProductCarousel} from './components/ProductCarousel';
+export {ProductResearchCard} from './components/ProductResearchCard';
 export {ComparisonTable} from './components/ComparisonTable';
 export {ComparisonSummary} from './components/ComparisonSummary';
 export {BundleDisplay} from './components/BundleDisplay';

--- a/app/components/Generative/ResponseContent/rendering/component-registry.ts
+++ b/app/components/Generative/ResponseContent/rendering/component-registry.ts
@@ -8,6 +8,7 @@ import {
   renderNextActionsBar,
   renderProductCard,
   renderProductCarousel,
+  renderProductResearchCard,
   renderText,
 } from './component-renderers';
 import type {ResponseComponentRendererProps} from './render-context';
@@ -20,6 +21,7 @@ export type ResponseComponentRegistry = Record<
 export const responseComponentRegistry: ResponseComponentRegistry = {
   ProductCard: renderProductCard,
   ProductCarousel: renderProductCarousel,
+  ProductResearchCard: renderProductResearchCard,
   ComparisonTable: renderComparisonTable,
   ComparisonSummary: renderComparisonSummary,
   BundleDisplay: renderBundleDisplay,

--- a/app/components/Generative/ResponseContent/rendering/component-renderers.tsx
+++ b/app/components/Generative/ResponseContent/rendering/component-renderers.tsx
@@ -8,7 +8,10 @@ import {BundleDisplay} from '../components/BundleDisplay';
 import {NextActionsBar} from '../components/NextActionsBar';
 import {ProductResearchCard} from '../components/ProductResearchCard';
 import {resolveTemplateData} from '~/lib/generative/a2ui/data-binding-resolver';
-import {resolveProductId} from '~/lib/generative/product/product-identifier';
+import {
+  normalizeProductId,
+  resolveProductId,
+} from '~/lib/generative/product/product-identifier';
 import type {ResponseComponentRendererProps} from './render-context';
 
 type RenderableProductSource = {
@@ -192,12 +195,9 @@ export function renderProductResearchCard({
   const items = resolveTemplateData('/items', renderContext.dataModel) as
     | ProductResearchSource[]
     | undefined;
-  const productId =
-    typeof resolvedProps.ec_product_id === 'string'
-      ? resolvedProps.ec_product_id
-      : '';
+  const productId = normalizeProductId(resolvedProps.ec_product_id) ?? '';
   const product =
-    items?.find((item) => item.ec_product_id === productId) ??
+    items?.find((item) => resolveProductId(item) === productId) ??
     items?.[0] ??
     null;
   const summary =

--- a/app/components/Generative/ResponseContent/rendering/component-renderers.tsx
+++ b/app/components/Generative/ResponseContent/rendering/component-renderers.tsx
@@ -6,6 +6,7 @@ import {ComparisonTable} from '../components/ComparisonTable';
 import {ComparisonSummary} from '../components/ComparisonSummary';
 import {BundleDisplay} from '../components/BundleDisplay';
 import {NextActionsBar} from '../components/NextActionsBar';
+import {ProductResearchCard} from '../components/ProductResearchCard';
 import {resolveTemplateData} from '~/lib/generative/a2ui/data-binding-resolver';
 import {resolveProductId} from '~/lib/generative/product/product-identifier';
 import type {ResponseComponentRendererProps} from './render-context';
@@ -34,6 +35,8 @@ type ProductCardSource = RenderableProductSource &
     ec_colors?: string[] | null;
     ec_selected_color?: string | null;
   };
+
+type ProductResearchSource = ProductCardSource;
 
 function getPrimaryCategory(product: {ec_category?: string[] | null}) {
   return Array.isArray(product.ec_category) && product.ec_category.length > 0
@@ -177,6 +180,45 @@ export function renderComparisonSummary({
       ? resolvedProps.text
       : ((resolvedProps.text as any)?.literalString ?? '');
   return <ComparisonSummary key={renderContext.componentId} text={text} />;
+}
+
+export function renderProductResearchCard({
+  componentProps,
+  resolved,
+  renderContext,
+  interactionHandlers,
+}: ResponseComponentRendererProps): ReactNode {
+  const resolvedProps = (resolved as any).component || resolved;
+  const items = resolveTemplateData('/items', renderContext.dataModel) as
+    | ProductResearchSource[]
+    | undefined;
+  const productId =
+    typeof resolvedProps.ec_product_id === 'string'
+      ? resolvedProps.ec_product_id
+      : '';
+  const product =
+    items?.find((item) => item.ec_product_id === productId) ??
+    items?.[0] ??
+    null;
+  const summary =
+    typeof resolvedProps.summary === 'string' ? resolvedProps.summary : '';
+  const bullets = Array.isArray(resolvedProps.bullets)
+    ? resolvedProps.bullets.filter(
+        (bullet: unknown): bullet is string =>
+          typeof bullet === 'string' && bullet.trim().length > 0,
+      )
+    : [];
+
+  return (
+    <ProductResearchCard
+      key={renderContext.componentId}
+      product={product}
+      summary={summary}
+      bullets={bullets}
+      isLoading={Boolean(componentProps.isLoading) || renderContext.isSkeletonSurface}
+      onProductSelect={interactionHandlers.onProductSelect}
+    />
+  );
 }
 
 export function renderBundleDisplay({

--- a/app/lib/generative/a2ui/commerce-catalog.json
+++ b/app/lib/generative/a2ui/commerce-catalog.json
@@ -85,11 +85,13 @@
         },
         "summary": {
           "type": "string",
-          "description": "Short AI-generated product research summary"
+          "description": "Short AI-generated product research summary",
+          "optional": true
         },
         "bullets": {
           "type": "array",
           "description": "Supporting product research bullets",
+          "optional": true,
           "items": {
             "type": "string"
           }

--- a/app/lib/generative/a2ui/commerce-catalog.json
+++ b/app/lib/generative/a2ui/commerce-catalog.json
@@ -76,6 +76,27 @@
       }
     },
     {
+      "id": "ProductResearchCard",
+      "description": "Display a product deep-dive with one bound product plus AI-generated summary and feature bullets. Use this for research intent responses.",
+      "properties": {
+        "ec_product_id": {
+          "type": "string",
+          "description": "Product identifier used to match the bound item from /items"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Short AI-generated product research summary"
+        },
+        "bullets": {
+          "type": "array",
+          "description": "Supporting product research bullets",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
       "id": "ComparisonTable",
       "description": "Side-by-side product comparison table with key attributes. Use this when the user requests to compare multiple products.",
       "properties": {


### PR DESCRIPTION
Adds a new “ProductResearchCard” A2UI component to support product research intent responses (deep-dive summary + key feature bullets) within the Generative ResponseContent rendering pipeline.

Changes:

Extends the A2UI commerce catalog with a new ProductResearchCard component schema.
Adds a new ProductResearchCard React component (with skeleton UI) and exports it.
Registers and renders ProductResearchCard via the response component registry/renderers.

<img width="1148" height="673" alt="Screenshot 2026-04-08 at 3 37 43 PM" src="https://github.com/user-attachments/assets/5f5606f9-c5e4-4bfc-91c8-6fe5193eb51b" />
