### PR TITLE
COMSHOPX-364 Update agent-smith to invoke prod agentic endpoint

### DIFF
--- a/CONVERSATIONAL_A2UI_RENDERING.md
+++ b/CONVERSATIONAL_A2UI_RENDERING.md
@@ -256,10 +256,23 @@ The key responsibilities there are:
 
 - resolve bound component props against the current `DataModelStore`
 - resolve templated list items
+- resolve bound values nested inside arrays
 - support the A2UI-style data binding references used by catalog components
 
 By the time a component reaches `ComponentRenderer`, its bound values are
 already normalized through this layer.
+
+That array handling matters for commerce payloads where props like
+`ProductResearchCard.bullets` can arrive as:
+
+```json
+[
+  {"literalString": "Best when you want stretch and comfort."},
+  {"literalString": "A snug fit improves warmth retention."}
+]
+```
+
+rather than plain `string[]`.
 
 ## 10. How Surfaces Reach the Assistant Message
 
@@ -351,6 +364,11 @@ Maps `catalogComponentId` values to renderer functions.
 
 Contains the adapter functions that translate A2UI component definitions into
 the props expected by the actual React UI components.
+
+Current compatibility behavior worth knowing:
+
+- `ProductCarousel` accepts both `heading` and legacy `headline`
+- `ComparisonTable` accepts both `heading` and legacy `headline`
 
 This is the main seam between:
 

--- a/CONVERSATIONAL_FLOW.md
+++ b/CONVERSATIONAL_FLOW.md
@@ -117,6 +117,7 @@ Current behavior:
 - accepts a frontend payload with:
   - `message`
   - `sessionId`
+  - `conversationToken`
   - `locale`
   - `view`
 - looks up existing stored conversation history for the session
@@ -132,6 +133,21 @@ The route is responsible for shaping the upstream request, including:
 - conversation/session identifiers
 - locale/view context
 - any backend-specific forwarded properties required by the active agent
+
+### Conversation continuity
+
+Conversation continuation uses a pair of values:
+
+- `sessionId`
+- `conversationToken`
+
+Current client behavior is:
+
+- first turn sends no `conversationToken`
+- follow-up turns send both `sessionId` and `conversationToken`
+- the token is treated as opaque server continuation state
+- the latest token is captured from SSE lifecycle events and written back to the
+  active conversation record
 
 If you need to change how the agent is invoked, start in:
 
@@ -170,6 +186,14 @@ This class is responsible for:
 - reacting to tool/status/custom events
 - asking the structured-response adapter to patch metadata for A2UI content
 
+It also owns streamed conversation continuity updates from lifecycle events:
+
+- `turn_started`
+- `turn_complete`
+
+Those events are where the latest `conversationToken` is captured for the next
+turn.
+
 ### React state mutation boundary
 
 The only layer that mutates `ConversationRecord[]` during streaming is:
@@ -202,6 +226,13 @@ Conversation-specific hooks live beside them:
 
 This is the main place to look if you want to change message storage, local
 conversation lifecycle, or how active/visible messages are derived.
+
+`ConversationRecord` persists both:
+
+- `sessionId`
+- `conversationToken`
+
+so the frontend can continue the same upstream conversation across turns.
 
 ## 8. Thinking and View State
 
@@ -320,6 +351,9 @@ For the detailed A2UI render path, read:
 
 - `app/lib/generative/use-assistant-streaming.ts`
 
+This layer is also where follow-up turns include the stored
+`conversationToken`.
+
 ### Change how the server calls the backend agent
 
 - `app/routes/api.agentic.conversation.ts`
@@ -327,6 +361,11 @@ For the detailed A2UI render path, read:
 ### Change conversation creation, storage, or active conversation logic
 
 - `app/lib/generative/conversation/`
+
+This includes persistence of the conversation continuity pair:
+
+- `sessionId`
+- `conversationToken`
 
 ### Change transcript ordering or message row composition
 

--- a/app/components/FeaturePanel.tsx
+++ b/app/components/FeaturePanel.tsx
@@ -27,17 +27,17 @@ const AGENT_RUNTIME_CHOICES: Array<{
   {
     value: 'default',
     label: 'Org Default - no override',
-    description: 'Use the org default with no per-request override.',
+    description: 'Use the dev org default with no per-request override.',
   },
   {
     value: 'nrf-demo-agent',
     label: 'Demo Agent',
-    description: 'Routes requests to demo-agent built for NRF.',
+    description: 'Routes requests to demo-agent built for NRF (dev)',
   },
   {
     value: 'agent-smith-commerce-agent',
     label: 'Agent Smith Commerce Agent',
-    description: 'Routes requests to agent-smith commerce-agent.',
+    description: 'Routes requests to agent-smith commerce-agent (prod)',
   },
 ];
 
@@ -126,8 +126,8 @@ export function FeaturePanel() {
                               </h3>
                               <p className="mt-1 text-xs text-gray-500">
                                 Applies to conversational requests only. Uses a
-                                per-request override on the dev org for the Coveo agentic
-                                endpoint.
+                                per-request override on the dev org. Agent Smith uses
+                                the prod org with no feature-flag override.
                               </p>
                             </div>
                             <div className="space-y-3">

--- a/app/components/Generative/ResponseContent/components/ComparisonTable.tsx
+++ b/app/components/Generative/ResponseContent/components/ComparisonTable.tsx
@@ -186,7 +186,7 @@ export function ComparisonTable({
                         alt={product.name}
                         className="h-[200px] w-[200px] mx-auto object-cover bg-gray-50 group-hover:opacity-90 transition-opacity"
                       />
-                      <p className="mt-3 text-sm font-semibold text-gray-900 leading-snug truncate">
+                      <p className="mt-3 text-sm font-semibold text-gray-900 leading-snug truncate text-center">
                         {product.name}
                       </p>
                     </button>

--- a/app/lib/generative/a2ui/commerce-catalog.json
+++ b/app/lib/generative/a2ui/commerce-catalog.json
@@ -60,9 +60,14 @@
       "id": "ProductCarousel",
       "description": "Horizontal scrolling list of products. Use this for product recommendations, search results, or category browsing within a conversation.",
       "properties": {
+        "heading": {
+          "type": "string",
+          "description": "Preferred title/heading for the carousel",
+          "optional": true
+        },
         "headline": {
           "type": "string",
-          "description": "Title/heading for the carousel",
+          "description": "Legacy title/heading for the carousel. Prefer `heading` for new payloads.",
           "optional": true
         },
         "products": {
@@ -102,9 +107,14 @@
       "id": "ComparisonTable",
       "description": "Side-by-side product comparison table with key attributes. Use this when the user requests to compare multiple products.",
       "properties": {
+        "heading": {
+          "type": "string",
+          "description": "Preferred title for the comparison",
+          "optional": true
+        },
         "headline": {
           "type": "string",
-          "description": "Title for the comparison",
+          "description": "Legacy title for the comparison. Prefer `heading` for new payloads.",
           "optional": true
         },
         "products": {
@@ -120,6 +130,65 @@
           "description": "Attribute names to compare",
           "items": {
             "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "id": "ComparisonSummary",
+      "description": "Short recommendation or trade-off summary shown after a comparison table.",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Comparison summary text"
+        }
+      }
+    },
+    {
+      "id": "BundleDisplay",
+      "description": "Config-driven bundle layout that resolves product slot surfaces via `surfaceRef`.",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Optional bundle display title",
+          "optional": true
+        },
+        "bundles": {
+          "type": "array",
+          "description": "Bundle definitions to render",
+          "items": {
+            "type": "object",
+            "properties": {
+              "bundleId": {
+                "type": "string",
+                "description": "Stable bundle identifier"
+              },
+              "label": {
+                "type": "string",
+                "description": "Display label for the bundle"
+              },
+              "description": {
+                "type": "string",
+                "description": "Short bundle description"
+              },
+              "slots": {
+                "type": "array",
+                "description": "Slot definitions resolved from prior bundle slot surfaces",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "categoryLabel": {
+                      "type": "string",
+                      "description": "Display label for the slot category"
+                    },
+                    "surfaceRef": {
+                      "type": "string",
+                      "description": "Referenced `bundle-surface-*` surface containing the selected product"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/app/lib/generative/a2ui/data-binding-resolver.ts
+++ b/app/lib/generative/a2ui/data-binding-resolver.ts
@@ -92,12 +92,7 @@ export function resolveComponentBindings(
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       // Check if this is a BoundValue
       const obj = value as Record<string, unknown>;
-      if (
-        'path' in obj ||
-        'literalString' in obj ||
-        'literalNumber' in obj ||
-        'literalBoolean' in obj
-      ) {
+      if (isBoundValueObject(obj)) {
         resolved[key] = resolveBoundValue(value, dataModel);
       } else {
         // Recursively resolve nested objects
@@ -106,9 +101,7 @@ export function resolveComponentBindings(
     } else if (Array.isArray(value)) {
       // Resolve array items
       resolved[key] = value.map((item) =>
-        typeof item === 'object' && item !== null
-          ? resolveComponentBindings(item as Record<string, unknown>, dataModel)
-          : item,
+        resolveArrayItem(item, dataModel),
       );
     } else {
       resolved[key] = value;
@@ -135,4 +128,28 @@ export function resolveTemplateData(
   }
 
   return [];
+}
+
+function resolveArrayItem(item: unknown, dataModel: DataModelStore): unknown {
+  if (!item || typeof item !== 'object') {
+    return item;
+  }
+
+  if (Array.isArray(item)) {
+    return item.map((entry) => resolveArrayItem(entry, dataModel));
+  }
+
+  const record = item as Record<string, unknown>;
+  return isBoundValueObject(record)
+    ? resolveBoundValue(record, dataModel)
+    : resolveComponentBindings(record, dataModel);
+}
+
+function isBoundValueObject(value: Record<string, unknown>): value is BoundValue {
+  return (
+    'path' in value ||
+    'literalString' in value ||
+    'literalNumber' in value ||
+    'literalBoolean' in value
+  );
 }

--- a/app/lib/generative/agent-runtime.ts
+++ b/app/lib/generative/agent-runtime.ts
@@ -37,9 +37,8 @@ export function getFeatureFlagOverridesForAgentRuntime(
   switch (selection) {
     case 'nrf-demo-agent':
       return {[DEMO_AGENT_CORE_RUNTIME_FLAG]: true};
-    case 'agent-smith-commerce-agent':
-      return {[DEMO_AGENT_CORE_RUNTIME_FLAG]: false};
     case 'default':
+    case 'agent-smith-commerce-agent':
     default:
       return null;
   }

--- a/app/lib/generative/conversation/merge.ts
+++ b/app/lib/generative/conversation/merge.ts
@@ -25,6 +25,8 @@ export function mergeConversations(
       ...newer,
       localId: preserveLocalId ?? current.localId,
       sessionId: newer.sessionId ?? older.sessionId ?? null,
+      conversationToken:
+        newer.conversationToken ?? older.conversationToken ?? null,
       title: newer.title || older.title,
       messages: newer.messages.length ? newer.messages : older.messages,
       isPersisted: newer.isPersisted ?? older.isPersisted,

--- a/app/lib/generative/conversation/record.ts
+++ b/app/lib/generative/conversation/record.ts
@@ -7,6 +7,7 @@ import {generateId} from './id';
 export type ConversationRecord = {
   localId: string;
   sessionId: string | null;
+  conversationToken: string | null;
   title: string;
   createdAt: string;
   updatedAt: string;
@@ -25,6 +26,7 @@ export function mapSummaryToRecord(
   return {
     localId: generateId(),
     sessionId: summary.id,
+    conversationToken: summary.conversationToken ?? null,
     title: summary.title,
     createdAt: summary.createdAt,
     updatedAt: summary.updatedAt,
@@ -38,6 +40,7 @@ export function recordToSummary(
 ): ConversationSummary {
   return {
     id: record.sessionId ?? record.localId,
+    conversationToken: record.conversationToken,
     title: record.title,
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
@@ -53,6 +56,7 @@ export function createEmptyConversation(
   return {
     localId: generateId(),
     sessionId: null,
+    conversationToken: null,
     title: label,
     createdAt: timestamp,
     updatedAt: timestamp,

--- a/app/lib/generative/conversation/use-send-message.ts
+++ b/app/lib/generative/conversation/use-send-message.ts
@@ -23,6 +23,7 @@ type UseSendMessageOptions = {
   streamAssistantResponse: (args: {
     conversationLocalId: string;
     sessionId: string | null;
+    conversationToken: string | null;
     userMessage: string;
     showInitialStatus?: boolean;
   }) => Promise<void>;
@@ -113,6 +114,7 @@ export function useSendMessage({
       logDebug('sending message', {
         localId: updated.localId,
         sessionId: updated.sessionId,
+        hasConversationToken: Boolean(updated.conversationToken),
         text: trimmed,
       });
 
@@ -126,6 +128,7 @@ export function useSendMessage({
           nextState.map((conversation) => ({
             localId: conversation.localId,
             sessionId: conversation.sessionId,
+            hasConversationToken: Boolean(conversation.conversationToken),
             updatedAt: conversation.updatedAt,
             messageCount: conversation.messages.length,
           })),
@@ -139,11 +142,13 @@ export function useSendMessage({
       logDebug('invoking stream', {
         localId: updated.localId,
         sessionId: updated.sessionId,
+        hasConversationToken: Boolean(updated.conversationToken),
       });
 
       await streamAssistantResponse({
         conversationLocalId: updated.localId,
         sessionId: updated.sessionId,
+        conversationToken: updated.conversationToken,
         userMessage: trimmed,
         showInitialStatus: shouldShowInitialStatus,
       });

--- a/app/lib/generative/session/assistant-stream-session.ts
+++ b/app/lib/generative/session/assistant-stream-session.ts
@@ -29,6 +29,7 @@ export class AssistantStreamSession {
   private structuredResponseAdapter;
   private onThinkingUpdate;
   private resolvedSessionId: string | null;
+  private resolvedConversationToken: string | null;
   private assistantMessageId: string | null = null;
   private accumulatedContent = '';
   private activeReasoningMessageId: string | null = null;
@@ -41,11 +42,13 @@ export class AssistantStreamSession {
 
   constructor({
     initialSessionId,
+    initialConversationToken,
     updater,
     structuredResponseAdapter,
     onThinkingUpdate,
   }: AssistantStreamSessionOptions) {
     this.resolvedSessionId = initialSessionId;
+    this.resolvedConversationToken = initialConversationToken;
     this.updater = updater;
     this.structuredResponseAdapter = structuredResponseAdapter;
     this.onThinkingUpdate = onThinkingUpdate;
@@ -96,6 +99,7 @@ export class AssistantStreamSession {
         this.syncAssistantMetadata();
         return {complete: true};
       }
+      case 'turn_complete':
       case 'REASONING_START':
       case 'REASONING_END':
       case 'TEXT_MESSAGE_END':
@@ -187,7 +191,10 @@ export class AssistantStreamSession {
 
   finalizeAfterStream(): StreamHandlingResult {
     this.finalizeAssistantResponse();
-    this.updater.finalizeConversation(this.resolvedSessionId);
+    this.updater.finalizeConversation(
+      this.resolvedSessionId,
+      this.resolvedConversationToken,
+    );
 
     if (!this.turnCompleted && !this.capturedErrorMessage) {
       if (this.structuredResponseAdapter?.hasSyncedContent()) {
@@ -204,6 +211,10 @@ export class AssistantStreamSession {
 
   getResolvedSessionId() {
     return this.resolvedSessionId;
+  }
+
+  getResolvedConversationToken() {
+    return this.resolvedConversationToken;
   }
 
   hasCapturedError() {
@@ -422,50 +433,102 @@ export class AssistantStreamSession {
     this.pushAssistantMessage(text, 'error');
   }
 
-  private updateResolvedSession(sessionId: string | null) {
-    if (!sessionId || sessionId === this.resolvedSessionId) {
+  private updateResolvedContinuation(
+    sessionId: string | null,
+    conversationToken: string | null,
+  ) {
+    const nextUpdate: {
+      sessionId?: string | null;
+      conversationToken?: string | null;
+    } = {};
+
+    if (sessionId && sessionId !== this.resolvedSessionId) {
+      this.resolvedSessionId = sessionId;
+      nextUpdate.sessionId = sessionId;
+    }
+
+    if (
+      conversationToken &&
+      conversationToken !== this.resolvedConversationToken
+    ) {
+      this.resolvedConversationToken = conversationToken;
+      nextUpdate.conversationToken = conversationToken;
+    }
+
+    if (
+      nextUpdate.sessionId === undefined &&
+      nextUpdate.conversationToken === undefined
+    ) {
       return;
     }
 
-    this.resolvedSessionId = sessionId;
-    this.updater.updateConversationSession(sessionId);
+    this.updater.updateConversationContinuation(nextUpdate);
   }
 
-  private readSessionId(value: unknown): string | null {
+  private readContinuation(value: unknown): {
+    sessionId: string | null;
+    conversationToken: string | null;
+  } {
     if (!value || typeof value !== 'object') {
-      return null;
+      return {
+        sessionId: null,
+        conversationToken: null,
+      };
     }
 
     const record = value as Record<string, unknown>;
+    const payload =
+      record.payload && typeof record.payload === 'object'
+        ? (record.payload as Record<string, unknown>)
+        : null;
     const candidates = [
       record.threadId,
       record.sessionId,
       record.conversationSessionId,
+      payload?.threadId,
+      payload?.sessionId,
+      payload?.conversationSessionId,
     ];
+    let sessionId: string | null = null;
 
     for (const candidate of candidates) {
       if (typeof candidate === 'string' && candidate.trim()) {
-        return candidate.trim();
+        sessionId = candidate.trim();
+        break;
       }
     }
 
-    return null;
+    const tokenCandidates = [
+      record.conversationToken,
+      payload?.conversationToken,
+    ];
+    let conversationToken: string | null = null;
+
+    for (const candidate of tokenCandidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        conversationToken = candidate.trim();
+        break;
+      }
+    }
+
+    return {
+      sessionId,
+      conversationToken,
+    };
   }
 
-  private resolveSessionIdFromEvent(event: AssistantStreamEvent): string | null {
-    if ('threadId' in event && typeof event.threadId === 'string') {
-      return event.threadId;
-    }
-
+  private resolveContinuationFromEvent(event: AssistantStreamEvent) {
     if (event.type === 'CUSTOM') {
-      return this.readSessionId(event.value);
+      return this.readContinuation(event.value);
     }
 
-    return null;
+    return this.readContinuation(event);
   }
 
   private updateSessionFromEvent(event: AssistantStreamEvent) {
-    this.updateResolvedSession(this.resolveSessionIdFromEvent(event));
+    const {sessionId, conversationToken} =
+      this.resolveContinuationFromEvent(event);
+    this.updateResolvedContinuation(sessionId, conversationToken);
   }
 
   private resolveDisplayText(value: unknown, fallback: string): string {

--- a/app/lib/generative/session/conversation-state-updater.ts
+++ b/app/lib/generative/session/conversation-state-updater.ts
@@ -114,21 +114,46 @@ export class ConversationStateUpdater {
   }
 
   updateConversationSession(sessionId: string) {
-    this.applyUpdate((conversation) => ({
-      ...conversation,
-      sessionId,
-    }));
+    this.updateConversationContinuation({sessionId});
   }
 
-  finalizeConversation(sessionId: string | null) {
+  updateConversationContinuation({
+    sessionId,
+    conversationToken,
+  }: {
+    sessionId?: string | null;
+    conversationToken?: string | null;
+  }) {
+    this.applyUpdate((conversation) => {
+      const nextConversation = {...conversation};
+
+      if (sessionId !== undefined) {
+        nextConversation.sessionId = sessionId;
+      }
+
+      if (conversationToken !== undefined) {
+        nextConversation.conversationToken = conversationToken;
+      }
+
+      return nextConversation;
+    });
+  }
+
+  finalizeConversation(
+    sessionId: string | null,
+    conversationToken: string | null,
+  ) {
     const updatedAt = new Date().toISOString();
 
     this.applyUpdate((conversation) => {
       const nextSessionId = sessionId ?? conversation.sessionId;
+      const nextConversationToken =
+        conversationToken ?? conversation.conversationToken;
 
       return {
         ...conversation,
         sessionId: nextSessionId,
+        conversationToken: nextConversationToken,
         updatedAt,
         isPersisted: conversation.isPersisted || Boolean(nextSessionId),
       };

--- a/app/lib/generative/session/types.ts
+++ b/app/lib/generative/session/types.ts
@@ -5,6 +5,7 @@ import type {ConversationStateUpdater} from './conversation-state-updater';
 
 export type AssistantStreamSessionOptions = {
   initialSessionId: string | null;
+  initialConversationToken: string | null;
   updater: ConversationStateUpdater;
   structuredResponseAdapter?: StructuredResponseAdapter;
   onThinkingUpdate?: (snapshot: ThinkingUpdateSnapshot) => void;

--- a/app/lib/generative/streaming/sse-parser.ts
+++ b/app/lib/generative/streaming/sse-parser.ts
@@ -30,6 +30,16 @@ function normalizeEvent(fallbackName: string, payload: unknown): unknown {
   }
 
   if (fallbackName && fallbackName !== 'message') {
+    if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+      // Named SSE lifecycle events such as `turn_started` and `turn_complete`
+      // carry structured objects without an embedded `type`. Flatten them here
+      // so downstream code can treat them like first-class typed events.
+      return {
+        type: fallbackName,
+        ...(payload as Record<string, unknown>),
+      };
+    }
+
     return {
       type: fallbackName,
       payload,

--- a/app/lib/generative/streaming/sse-parser.ts
+++ b/app/lib/generative/streaming/sse-parser.ts
@@ -35,8 +35,8 @@ function normalizeEvent(fallbackName: string, payload: unknown): unknown {
       // carry structured objects without an embedded `type`. Flatten them here
       // so downstream code can treat them like first-class typed events.
       return {
-        type: fallbackName,
         ...(payload as Record<string, unknown>),
+        type: fallbackName,
       };
     }
 

--- a/app/lib/generative/streaming/types.ts
+++ b/app/lib/generative/streaming/types.ts
@@ -3,6 +3,7 @@ import type {ConversationThinkingUpdate} from '~/types/conversation';
 
 export type SessionIdentifier = {
   sessionId: string | null;
+  conversationToken: string | null;
 };
 
 export type RunStartedEvent = {
@@ -111,6 +112,14 @@ export type CustomEvent = {
 
 export type TurnStartedEvent = {
   type: 'turn_started';
+  conversationSessionId?: string;
+  conversationToken?: string;
+};
+
+export type TurnCompleteEvent = {
+  type: 'turn_complete';
+  conversationSessionId?: string;
+  conversationToken?: string;
 };
 
 export type UnknownEvent = {
@@ -168,6 +177,7 @@ export type ActivitySnapshotEvent = {
 
 export type AssistantStreamEvent =
   | TurnStartedEvent
+  | TurnCompleteEvent
   | RunStartedEvent
   | RunFinishedEvent
   | RunErrorEvent
@@ -198,6 +208,7 @@ export type ThinkingUpdateSnapshot = {
 export type StreamArgs = {
   conversationLocalId: string;
   sessionId: string | null;
+  conversationToken: string | null;
   userMessage: string;
   showInitialStatus?: boolean;
   onThinkingUpdate?: (snapshot: ThinkingUpdateSnapshot) => void;

--- a/app/lib/generative/use-assistant-streaming.ts
+++ b/app/lib/generative/use-assistant-streaming.ts
@@ -52,6 +52,7 @@ export function useAssistantStreaming({
     async ({
       conversationLocalId,
       sessionId,
+      conversationToken,
       userMessage,
       showInitialStatus,
       onThinkingUpdate: streamCallback,
@@ -79,6 +80,7 @@ export function useAssistantStreaming({
       });
       const session = new AssistantStreamSession({
         initialSessionId: sessionId,
+        initialConversationToken: conversationToken,
         updater,
         structuredResponseAdapter,
         onThinkingUpdate: updateCallback,
@@ -110,6 +112,7 @@ export function useAssistantStreaming({
         logInfo('streaming request start', {
           conversationLocalId,
           sessionId,
+          hasConversationToken: Boolean(conversationToken),
           endpoint,
           requestedAgentRuntime,
         });
@@ -127,6 +130,7 @@ export function useAssistantStreaming({
           body: JSON.stringify({
             message: userMessage,
             sessionId: sessionId ?? undefined,
+            conversationToken: conversationToken ?? undefined,
             locale,
             view,
           }),

--- a/app/lib/generative/use-auto-retry.ts
+++ b/app/lib/generative/use-auto-retry.ts
@@ -11,6 +11,7 @@ type UseAutoRetryOptions = {
   streamError: string | null;
   isStreaming: boolean;
   sessionId: string | null;
+  conversationToken: string | null;
   conversationId: string | null;
   setConversations: Dispatch<SetStateAction<ConversationRecord[]>>;
   setStreamError: Dispatch<SetStateAction<string | null>>;
@@ -28,6 +29,7 @@ export function useAutoRetry({
   streamError,
   isStreaming,
   sessionId,
+  conversationToken,
   conversationId,
   setConversations,
   setStreamError,
@@ -74,6 +76,11 @@ export function useAutoRetry({
       return;
     }
 
+    if (!conversationToken) {
+      logDebug('cannot auto-retry: no conversation token');
+      return;
+    }
+
     retryCountRef.current += 1;
     isRetryingRef.current = true;
 
@@ -109,6 +116,7 @@ export function useAutoRetry({
     streamError,
     isStreaming,
     sessionId,
+    conversationToken,
     conversationId,
     sendMessageRef,
     setStreamError,

--- a/app/routes/($locale).generative.tsx
+++ b/app/routes/($locale).generative.tsx
@@ -144,6 +144,7 @@ export default function GenerativeShoppingAssistant() {
     streamError,
     isStreaming,
     sessionId: activeConversation?.sessionId ?? null,
+    conversationToken: activeConversation?.conversationToken ?? null,
     conversationId: activeConversationId,
     setConversations,
     setStreamError,

--- a/app/routes/api.agentic.conversation.ts
+++ b/app/routes/api.agentic.conversation.ts
@@ -334,7 +334,12 @@ function resolveContextAgenticAccessToken(
     }
   )?.env?.[envVarName];
 
-  return typeof token === 'string' && token.trim() ? token : undefined;
+  if (typeof token !== 'string') {
+    return undefined;
+  }
+
+  const trimmedToken = token.trim();
+  return trimmedToken || undefined;
 }
 
 function upsertConversation(
@@ -515,7 +520,13 @@ function getRequiredAgenticAccessToken(
 }
 
 function resolveAgenticAccessToken(envVarName: AgenticAccessTokenEnvVar) {
-  return typeof process !== 'undefined'
-    ? process?.env?.[envVarName]
-    : undefined;
+  const token =
+    typeof process !== 'undefined' ? process?.env?.[envVarName] : undefined;
+
+  if (typeof token !== 'string') {
+    return undefined;
+  }
+
+  const trimmedToken = token.trim();
+  return trimmedToken || undefined;
 }

--- a/app/routes/api.agentic.conversation.ts
+++ b/app/routes/api.agentic.conversation.ts
@@ -76,6 +76,7 @@ async function handleStreamConversation(
 
   console.info('[api.agentic.conversation] streaming conversation', {
     hasSessionId: Boolean(body.sessionId),
+    hasConversationToken: Boolean(body.conversationToken),
     requestedAgentRuntime,
     targetEnvironment: runtimeConfig.targetEnvironment,
     featureFlagOverrideApplied: Boolean(runtimeConfig.featureFlagOverrides),
@@ -105,6 +106,7 @@ async function handleStreamConversation(
       cart: Array.isArray(body.cart) ? body.cart : [],
     },
     conversationSessionId: body.sessionId || undefined,
+    conversationToken: body.conversationToken || undefined,
     targetEngine: 'AGENT_CORE',
   } satisfies Record<string, unknown>;
 
@@ -275,6 +277,10 @@ function sanitizeConversation(
 
   return {
     id: conversation.id,
+    conversationToken:
+      typeof conversation.conversationToken === 'string'
+        ? conversation.conversationToken
+        : null,
     title,
     createdAt,
     updatedAt,
@@ -372,6 +378,7 @@ type ConversationStreamPayload = {
   message?: string;
   trackingId?: string;
   sessionId?: string;
+  conversationToken?: string;
   locale?: {
     language?: string;
     country?: string;

--- a/app/routes/api.agentic.conversation.ts
+++ b/app/routes/api.agentic.conversation.ts
@@ -14,12 +14,17 @@ import type {
 } from '~/types/conversation';
 import {CONVERSATIONS_SESSION_KEY} from '~/types/conversation';
 
-const AGENTIC_BASE_URL =
+const AGENTIC_DEV_BASE_URL =
   'https://platformdev.cloud.coveo.com/rest/organizations/barcasportsmcy01fvu/commerce/unstable/agentic';
+const AGENTIC_PROD_BASE_URL =
+  'https://platform.cloud.coveo.com/rest/organizations/barcagroupproductionkwvdy6lp/commerce/unstable/agentic';
 
 const MAX_CONVERSATIONS = 50;
 const MAX_CONTENT_LENGTH = 4000;
 const DEFAULT_TRACKING_ID = 'market_88728731922';
+type AgenticAccessTokenEnvVar =
+  | 'AGENTIC_ACCESS_TOKEN_DEV'
+  | 'AGENTIC_ACCESS_TOKEN_PROD';
 
 export async function action({request, context}: ActionFunctionArgs) {
   if (request.method === 'POST') {
@@ -64,13 +69,16 @@ async function handleStreamConversation(
   }
 
   const requestedAgentRuntime = resolveRequestedAgentRuntime(request);
-  const featureFlagOverrides =
-    getFeatureFlagOverridesForAgentRuntime(requestedAgentRuntime);
+  const runtimeConfig = resolveAgenticRuntimeConfig(
+    requestedAgentRuntime,
+    context,
+  );
 
   console.info('[api.agentic.conversation] streaming conversation', {
     hasSessionId: Boolean(body.sessionId),
     requestedAgentRuntime,
-    featureFlagOverrideApplied: Boolean(featureFlagOverrides),
+    targetEnvironment: runtimeConfig.targetEnvironment,
+    featureFlagOverrideApplied: Boolean(runtimeConfig.featureFlagOverrides),
   });
 
   const navigatorContext = new ServerSideNavigatorContextProvider(request);
@@ -105,8 +113,9 @@ async function handleStreamConversation(
 
   const agenticResponse = await streamAgenticConversation(payload, {
     signal: abortController.signal,
-    accessToken: extractAgenticAccessToken(context),
-    featureFlagOverrides,
+    baseUrl: runtimeConfig.baseUrl,
+    accessToken: runtimeConfig.accessToken,
+    featureFlagOverrides: runtimeConfig.featureFlagOverrides,
   });
 
   console.info('[api.agentic.conversation] upstream response', {
@@ -309,17 +318,17 @@ function sanitizeMessage(message: ConversationMessage): ConversationMessage {
   };
 }
 
-function extractAgenticAccessToken(
+function resolveContextAgenticAccessToken(
   context: ActionFunctionArgs['context'],
+  envVarName: AgenticAccessTokenEnvVar,
 ): string | undefined {
-  const token = (context as {env?: {AGENTIC_ACCESS_TOKEN?: string}})?.env
-    ?.AGENTIC_ACCESS_TOKEN;
+  const token = (
+    context as {
+      env?: Partial<Record<AgenticAccessTokenEnvVar, string>>;
+    }
+  )?.env?.[envVarName];
 
-  if (typeof token === 'string' && token.trim()) {
-    return token;
-  }
-
-  return undefined;
+  return typeof token === 'string' && token.trim() ? token : undefined;
 }
 
 function upsertConversation(
@@ -415,19 +424,19 @@ function createConversationId() {
 }
 
 type StreamAgenticConversationOptions = {
+  baseUrl: string;
   signal?: AbortSignal;
-  accessToken?: string | null;
+  accessToken: string;
   featureFlagOverrides?: Record<string, boolean> | null;
 };
 
 async function streamAgenticConversation(
   payload: unknown,
-  options: StreamAgenticConversationOptions = {},
+  options: StreamAgenticConversationOptions,
 ): Promise<Response> {
-  const accessToken = pickAccessToken(options.accessToken);
-  const url = new URL(`${AGENTIC_BASE_URL}/converse`);
+  const url = new URL(`${options.baseUrl}/converse`);
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${accessToken}`,
+    Authorization: `Bearer ${options.accessToken}`,
     'Content-Type': 'application/json',
   };
 
@@ -451,26 +460,55 @@ function resolveRequestedAgentRuntime(request: Request): AgentRuntimeSelection {
   );
 }
 
-function pickAccessToken(candidate?: string | null) {
-  const trimmedCandidate = candidate?.trim();
-  if (trimmedCandidate) {
-    return trimmedCandidate;
+function resolveAgenticRuntimeConfig(
+  requestedAgentRuntime: AgentRuntimeSelection,
+  context: ActionFunctionArgs['context'],
+) {
+  if (requestedAgentRuntime === 'agent-smith-commerce-agent') {
+    return {
+      targetEnvironment: 'prod' as const,
+      baseUrl: AGENTIC_PROD_BASE_URL,
+      accessToken: getRequiredAgenticAccessToken(
+        context,
+        'AGENTIC_ACCESS_TOKEN_PROD',
+      ),
+      featureFlagOverrides: null,
+    };
   }
 
-  const resolved = resolveAgenticAccessToken();
+  return {
+    targetEnvironment: 'dev' as const,
+    baseUrl: AGENTIC_DEV_BASE_URL,
+    accessToken: getRequiredAgenticAccessToken(
+      context,
+      'AGENTIC_ACCESS_TOKEN_DEV',
+    ),
+    featureFlagOverrides:
+      getFeatureFlagOverridesForAgentRuntime(requestedAgentRuntime),
+  };
+}
+
+function getRequiredAgenticAccessToken(
+  context: ActionFunctionArgs['context'],
+  envVarName: AgenticAccessTokenEnvVar,
+) {
+  const contextToken = resolveContextAgenticAccessToken(context, envVarName);
+  if (contextToken) {
+    return contextToken;
+  }
+
+  const resolved = resolveAgenticAccessToken(envVarName);
   if (resolved) {
     return resolved;
   }
 
   throw new Error(
-    'Missing AGENTIC_ACCESS_TOKEN environment variable for Agentic API access.',
+    `Missing ${envVarName} environment variable for Agentic API access.`,
   );
 }
 
-function resolveAgenticAccessToken() {
-  if (typeof process !== 'undefined' && process?.env?.AGENTIC_ACCESS_TOKEN) {
-    return process.env.AGENTIC_ACCESS_TOKEN;
-  }
-
-  return undefined;
+function resolveAgenticAccessToken(envVarName: AgenticAccessTokenEnvVar) {
+  return typeof process !== 'undefined'
+    ? process?.env?.[envVarName]
+    : undefined;
 }

--- a/app/types/conversation.ts
+++ b/app/types/conversation.ts
@@ -38,6 +38,7 @@ export interface ConversationMessage {
  */
 export interface ConversationSummary {
   id: string;
+  conversationToken?: string | null;
   title: string;
   createdAt: string;
   updatedAt: string;

--- a/env.d.ts
+++ b/env.d.ts
@@ -19,7 +19,8 @@ declare global {
   const process: {
     env: {
       NODE_ENV: 'production' | 'development';
-      AGENTIC_ACCESS_TOKEN?: string;
+      AGENTIC_ACCESS_TOKEN_DEV?: string;
+      AGENTIC_ACCESS_TOKEN_PROD?: string;
     };
   };
 
@@ -28,7 +29,8 @@ declare global {
   }
 
   interface ImportMetaEnv {
-    readonly AGENTIC_ACCESS_TOKEN?: string;
+    readonly AGENTIC_ACCESS_TOKEN_DEV?: string;
+    readonly AGENTIC_ACCESS_TOKEN_PROD?: string;
   }
 
   interface ImportMeta {


### PR DESCRIPTION
- routes Agent Smith to the prod agentic endpoint with AGENTIC_ACCESS_TOKEN_PROD, while keeping dev/default flows on the dev endpoint with AGENTIC_ACCESS_TOKEN_DEV
- adds conversationToken support across request shaping, SSE lifecycle handling, local conversation state, persistence, and auto-retry
- fixes A2UI array-bound value resolution so ProductResearchCard.bullets and similar array props render correctly
- aligns the commerce A2UI catalog/docs with current renderer support by adding ComparisonSummary, -BundleDisplay, and documenting heading plus legacy headline
- includes a small comparison-table UI tweak and debug panel copy updates