### PR TITLE
COMSHOPX-741 Improvements to the thinking panel

### DIFF
--- a/app/components/Generative/ThinkingStatusPanel.tsx
+++ b/app/components/Generative/ThinkingStatusPanel.tsx
@@ -1,6 +1,9 @@
 import {memo} from 'react';
 import cx from '~/lib/cx';
-import {buildThinkingProgressSteps} from '~/lib/generative/thinking/progress';
+import {
+  buildThinkingProgressSteps,
+  INITIAL_PROGRESS_STEP,
+} from '~/lib/generative/thinking/progress';
 import type {ConversationThinkingUpdate} from '~/types/conversation';
 
 type ThinkingStatusPanelProps = {
@@ -24,7 +27,9 @@ function ThinkingStatusPanelComponent({
 
   const latestStep = steps.at(-1);
   const isDone = !isStreaming;
-  const currentStepText = isDone ? 'All steps completed' : (latestStep?.label ?? '');
+  const currentStepText = isDone
+    ? 'All steps completed'
+    : (latestStep?.label ?? '');
   const stepCount = steps.length;
   const panelId = `thinking-updates-${steps[0]?.id ?? 'panel'}`;
 
@@ -63,12 +68,13 @@ function ThinkingStatusPanelComponent({
                   </span>
                 ) : null}
                 <span className="text-sm font-semibold text-slate-900">
-                  {currentStepText || 'Understanding your request'}
+                  {currentStepText || INITIAL_PROGRESS_STEP}
                 </span>
               </>
             ) : (
               <span className="text-sm font-semibold text-slate-900">
-                {currentStepText || 'Understanding your request'}...
+                {currentStepText || INITIAL_PROGRESS_STEP}
+                {!isDone ? '...' : ''}
               </span>
             )}
           </div>
@@ -124,12 +130,7 @@ function ThinkingStatusPanelComponent({
                     </span>
                   ) : (
                     <span
-                      className={cx(
-                        'mt-1 inline-flex h-3.5 w-3.5 shrink-0 rounded-full border-2',
-                        isDone || !step.isActive
-                          ? 'border-emerald-500 bg-white'
-                          : 'border-slate-300 bg-white',
-                      )}
+                      className="mt-1 inline-flex h-3.5 w-3.5 shrink-0 rounded-full border-2 border-emerald-500 bg-white"
                       aria-hidden="true"
                     >
                       <span className="m-auto h-1.5 w-1.5 rounded-full bg-emerald-500" />

--- a/app/components/Generative/ThinkingStatusPanel.tsx
+++ b/app/components/Generative/ThinkingStatusPanel.tsx
@@ -1,5 +1,6 @@
 import {memo} from 'react';
 import cx from '~/lib/cx';
+import {buildThinkingProgressSteps} from '~/lib/generative/thinking/progress';
 import type {ConversationThinkingUpdate} from '~/types/conversation';
 
 type ThinkingStatusPanelProps = {
@@ -15,53 +16,34 @@ function ThinkingStatusPanelComponent({
   isExpanded,
   onToggle,
 }: Readonly<ThinkingStatusPanelProps>) {
-  if (!updates.length) {
+  const steps = buildThinkingProgressSteps(updates, isStreaming);
+
+  if (!steps.length) {
     return null;
   }
 
-  const latestUpdate = updates.at(-1);
-  const latestText = latestUpdate?.text ?? '';
-  const updateCount = updates.length;
+  const latestStep = steps.at(-1);
   const isDone = !isStreaming;
-  const panelId = `thinking-updates-${updates[0]?.id ?? 'panel'}`;
+  const currentStepText = isDone ? 'All steps completed' : (latestStep?.label ?? '');
+  const stepCount = steps.length;
+  const panelId = `thinking-updates-${steps[0]?.id ?? 'panel'}`;
 
   return (
-    <div className="w-full rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm ring-1 ring-slate-100">
+    <div className="w-full rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm ring-1 ring-slate-100">
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full items-center justify-between gap-3 text-left"
+        className="flex w-full items-center justify-between gap-4 text-left"
         aria-expanded={isExpanded}
         aria-controls={panelId}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-4">
           {isDone ? (
             <span
-              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-emerald-100 bg-emerald-50 text-emerald-600"
+              className="inline-flex h-3.5 w-3.5 shrink-0 rounded-full border-2 border-emerald-500 bg-white"
               aria-hidden="true"
             >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 14 14"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M5.25 7.5L6.75 9L9.5 5.75"
-                  stroke="currentColor"
-                  strokeWidth="1.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <circle
-                  cx="7"
-                  cy="7"
-                  r="5.875"
-                  stroke="currentColor"
-                  strokeWidth="1.25"
-                />
-              </svg>
+              <span className="m-auto h-1.5 w-1.5 rounded-full bg-emerald-500" />
             </span>
           ) : (
             <span
@@ -73,17 +55,27 @@ function ThinkingStatusPanelComponent({
             </span>
           )}
           <div className="flex min-w-0 flex-col gap-0.5 ">
-            <span className="text-sm font-semibold text-slate-900">
-              Thinking
-            </span>
-            <span className="text-wrap text-xs text-slate-500">
-              {latestText || 'Gathering the best response...'}
-            </span>
+            {isExpanded ? (
+              <>
+                {!isDone ? (
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                    Current Step
+                  </span>
+                ) : null}
+                <span className="text-sm font-semibold text-slate-900">
+                  {currentStepText || 'Understanding your request'}
+                </span>
+              </>
+            ) : (
+              <span className="text-sm font-semibold text-slate-900">
+                {currentStepText || 'Understanding your request'}...
+              </span>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2 text-xs text-slate-500">
           <span>
-            {updateCount} step{updateCount === 1 ? '' : 's'}
+            {stepCount} step{stepCount === 1 ? '' : 's'}
           </span>
           <span
             className={cx(
@@ -116,30 +108,65 @@ function ThinkingStatusPanelComponent({
       </button>
       {isExpanded ? (
         <div id={panelId} className="mt-4">
-          <ul className="space-y-3 break-words text-sm text-slate-600">
-            {updates.map((update) => {
-              const bulletClass =
-                update.kind === 'tool'
-                  ? 'bg-sky-400'
-                  : update.kind === 'reasoning'
-                    ? 'bg-amber-400'
-                    : 'bg-indigo-400';
-              return (
-                <li
-                  key={update.id}
-                  className="flex max-w-full items-start gap-2"
+          {steps.map((step, index) => {
+            const isLastStep = index === steps.length - 1;
+
+            return (
+              <section key={step.id} className="flex gap-4">
+                <div className="flex w-4 shrink-0 flex-col items-center">
+                  {step.isActive ? (
+                    <span
+                      className="relative mt-1 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center"
+                      aria-hidden="true"
+                    >
+                      <span className="absolute inline-flex h-3.5 w-3.5 animate-ping rounded-full bg-indigo-200" />
+                      <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-indigo-500" />
+                    </span>
+                  ) : (
+                    <span
+                      className={cx(
+                        'mt-1 inline-flex h-3.5 w-3.5 shrink-0 rounded-full border-2',
+                        isDone || !step.isActive
+                          ? 'border-emerald-500 bg-white'
+                          : 'border-slate-300 bg-white',
+                      )}
+                      aria-hidden="true"
+                    >
+                      <span className="m-auto h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                    </span>
+                  )}
+                  {!isLastStep ? (
+                    <span
+                      className="my-1 w-px flex-1 border-l border-dashed border-slate-300"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </div>
+
+                <div
+                  className={cx('min-w-0 flex-1', !isLastStep ? 'pb-5' : '')}
                 >
-                  <span
+                  <p
                     className={cx(
-                      'mt-1 inline-flex h-1.5 w-1.5 shrink-0 rounded-full',
-                      bulletClass,
+                      'text-sm font-semibold',
+                      step.isActive ? 'text-slate-900' : 'text-slate-800',
                     )}
-                  />
-                  <span className="leading-5 break-words">{update.text}</span>
-                </li>
-              );
-            })}
-          </ul>
+                  >
+                    {step.label}
+                  </p>
+                  {step.bullets.length ? (
+                    <ul className="mt-1.5 space-y-1.5 break-words text-sm text-slate-500">
+                      {step.bullets.map((bullet) => (
+                        <li key={`${step.id}-${bullet}`} className="leading-5">
+                          {bullet}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              </section>
+            );
+          })}
         </div>
       ) : null}
     </div>

--- a/app/lib/generative/session/assistant-stream-session.ts
+++ b/app/lib/generative/session/assistant-stream-session.ts
@@ -17,6 +17,7 @@ import {
   INITIAL_PROGRESS_STEP,
   SUMMARY_PROGRESS_STEP,
   mapToolCallToProgress,
+  shouldSkipToolCallInProgress,
 } from '~/lib/generative/thinking/progress';
 import type {
   ConversationMessage,
@@ -545,6 +546,10 @@ export class AssistantStreamSession {
   }
 
   private handleToolCallStart(toolCallName: string | undefined) {
+    if (shouldSkipToolCallInProgress(toolCallName)) {
+      return;
+    }
+
     const mappedProgress = mapToolCallToProgress(toolCallName);
 
     if (mappedProgress) {

--- a/app/lib/generative/session/assistant-stream-session.ts
+++ b/app/lib/generative/session/assistant-stream-session.ts
@@ -4,7 +4,6 @@ import type {
 } from '~/lib/generative/streaming';
 import {
   CONNECTING_STATUS_MESSAGE,
-  DEFAULT_STATUS_MESSAGE,
   DEFAULT_TOOL_PROGRESS_MESSAGE,
   GENERIC_ERROR_MESSAGE,
   INTERRUPTED_ERROR_MESSAGE,
@@ -14,6 +13,11 @@ import {
   generateId,
   parseToolResultPayload,
 } from '~/lib/generative/conversation';
+import {
+  INITIAL_PROGRESS_STEP,
+  SUMMARY_PROGRESS_STEP,
+  mapToolCallToProgress,
+} from '~/lib/generative/thinking/progress';
 import type {
   ConversationMessage,
   ConversationThinkingUpdate,
@@ -37,8 +41,8 @@ export class AssistantStreamSession {
   private pendingFinalReasoningBlock: string | null = null;
   private capturedErrorMessage: string | null = null;
   private turnCompleted = false;
-  private seenStatusMessages = new Set<string>();
   private thinkingUpdates: ConversationThinkingUpdate[] = [];
+  private activeStepLabel: string | null = null;
 
   constructor({
     initialSessionId,
@@ -57,14 +61,13 @@ export class AssistantStreamSession {
   start(showInitialStatus?: boolean) {
     this.resetThinkingState();
 
-    const initialStatusMessage = showInitialStatus
-      ? CONNECTING_STATUS_MESSAGE
-      : DEFAULT_STATUS_MESSAGE;
+    if (showInitialStatus) {
+      this.pushAssistantMessage(CONNECTING_STATUS_MESSAGE, 'status', {
+        ephemeral: true,
+      });
+    }
 
-    this.pushAssistantMessage(initialStatusMessage, 'status', {
-      ephemeral: true,
-    });
-    this.recordThinkingUpdate(initialStatusMessage, 'status');
+    this.transitionToStep(INITIAL_PROGRESS_STEP);
   }
 
   handleEvent(event: AssistantStreamEvent): StreamHandlingResult {
@@ -73,7 +76,7 @@ export class AssistantStreamSession {
     switch (event.type) {
       case 'turn_started': {
         if (this.thinkingUpdates.length === 0) {
-          this.recordThinkingUpdate(DEFAULT_STATUS_MESSAGE, 'status');
+          this.transitionToStep(INITIAL_PROGRESS_STEP);
         } else {
           this.emitThinkingSnapshot();
         }
@@ -81,7 +84,7 @@ export class AssistantStreamSession {
       }
       case 'RUN_STARTED': {
         if (this.thinkingUpdates.length === 0) {
-          this.recordThinkingUpdate(DEFAULT_STATUS_MESSAGE, 'status');
+          this.transitionToStep(INITIAL_PROGRESS_STEP);
         } else {
           this.emitThinkingSnapshot();
         }
@@ -108,7 +111,7 @@ export class AssistantStreamSession {
         return {};
       }
       case 'REASONING_MESSAGE_START': {
-        this.demotePendingReasoningBlock();
+        this.clearPendingReasoningBlock();
         this.activeReasoningMessageId = event.messageId;
         this.activeReasoningBuffer = '';
         return {};
@@ -135,10 +138,12 @@ export class AssistantStreamSession {
           this.activeReasoningBuffer.trim() || null;
         this.activeReasoningBuffer = '';
         this.activeReasoningMessageId = null;
-        this.emitThinkingSnapshot();
         return {};
       }
       case 'TEXT_MESSAGE_START': {
+        if (event.role === 'assistant') {
+          this.transitionToStep(SUMMARY_PROGRESS_STEP);
+        }
         this.ensureAssistantMessage('');
         this.syncAssistantMetadata();
         return {};
@@ -151,14 +156,13 @@ export class AssistantStreamSession {
         return {};
       }
       case 'TOOL_CALL_START': {
-        const toolText = this.formatToolStartMessage(event.toolCallName);
-        if (this.seenStatusMessages.has(toolText)) {
-          return {};
-        }
-        this.seenStatusMessages.add(toolText);
-        this.recordThinkingUpdate(toolText, 'tool');
+        this.handleToolCallStart(event.toolCallName);
         if (!this.assistantMessageId) {
-          this.pushAssistantMessage(toolText, 'tool', {ephemeral: true});
+          this.pushAssistantMessage(
+            this.getToolStartMessage(event.toolCallName),
+            'tool',
+            {ephemeral: true},
+          );
         }
         return {};
       }
@@ -226,13 +230,12 @@ export class AssistantStreamSession {
     value: unknown,
   ): StreamHandlingResult {
     if (name === 'status' || name === 'status_update') {
-      const statusText = this.resolveDisplayText(value, DEFAULT_STATUS_MESSAGE);
-      if (!statusText || this.seenStatusMessages.has(statusText)) {
+      const statusText = this.resolveDisplayText(value, INITIAL_PROGRESS_STEP);
+      if (!statusText) {
         return {};
       }
 
-      this.seenStatusMessages.add(statusText);
-      this.recordThinkingUpdate(statusText, 'status');
+      this.transitionToStep(statusText);
       if (!this.assistantMessageId) {
         this.pushAssistantMessage(statusText, 'status', {ephemeral: true});
       }
@@ -244,6 +247,9 @@ export class AssistantStreamSession {
       const successNote =
         result.message ??
         this.resolveDisplayText(value, TOOL_RESULT_FALLBACK_MESSAGE);
+      if (this.looksLikeToolError(successNote)) {
+        return {};
+      }
       this.recordThinkingUpdate(successNote, 'tool');
       if (!this.assistantMessageId) {
         this.pushAssistantMessage(successNote, 'tool', {ephemeral: true});
@@ -286,6 +292,7 @@ export class AssistantStreamSession {
   private resetThinkingState() {
     this.thinkingUpdates = [];
     this.turnCompleted = false;
+    this.activeStepLabel = null;
     this.emitThinkingSnapshot();
   }
 
@@ -309,7 +316,8 @@ export class AssistantStreamSession {
       this.thinkingUpdates.length > 0
         ? {thinkingUpdates: [...this.thinkingUpdates]}
         : undefined;
-    const structuredMetadata = this.structuredResponseAdapter?.getMetadataPatch();
+    const structuredMetadata =
+      this.structuredResponseAdapter?.getMetadataPatch();
 
     if (!thinkingUpdates && !structuredMetadata) {
       return undefined;
@@ -390,12 +398,7 @@ export class AssistantStreamSession {
     this.setAssistantMessageContent(this.accumulatedContent);
   }
 
-  private demotePendingReasoningBlock() {
-    if (!this.pendingFinalReasoningBlock) {
-      return;
-    }
-
-    this.recordThinkingUpdate(this.pendingFinalReasoningBlock, 'reasoning');
+  private clearPendingReasoningBlock() {
     this.pendingFinalReasoningBlock = null;
   }
 
@@ -531,6 +534,55 @@ export class AssistantStreamSession {
     this.updateResolvedContinuation(sessionId, conversationToken);
   }
 
+  private transitionToStep(stepLabel: string) {
+    const trimmed = stepLabel.trim();
+    if (!trimmed || trimmed === this.activeStepLabel) {
+      return;
+    }
+
+    this.activeStepLabel = trimmed;
+    this.recordThinkingUpdate(trimmed, 'status');
+  }
+
+  private handleToolCallStart(toolCallName: string | undefined) {
+    const mappedProgress = mapToolCallToProgress(toolCallName);
+
+    if (mappedProgress) {
+      this.transitionToStep(mappedProgress.stepLabel);
+      if (!this.hasCurrentStepBullet(mappedProgress.bulletLabel)) {
+        this.recordThinkingUpdate(mappedProgress.bulletLabel, 'tool');
+      }
+      return;
+    }
+
+    const fallbackToolText = this.getToolStartMessage(toolCallName);
+    if (!this.hasCurrentStepBullet(fallbackToolText)) {
+      this.recordThinkingUpdate(fallbackToolText, 'tool');
+    }
+  }
+
+  private hasCurrentStepBullet(text: string) {
+    for (let index = this.thinkingUpdates.length - 1; index >= 0; index -= 1) {
+      const update = this.thinkingUpdates[index];
+      if (update.kind === 'status') {
+        break;
+      }
+      if (update.kind === 'tool' && update.text === text) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private looksLikeToolError(text: string) {
+    const normalized = text.trim().toLowerCase();
+    return (
+      normalized.startsWith('error:') ||
+      normalized.includes('http request failed')
+    );
+  }
+
   private resolveDisplayText(value: unknown, fallback: string): string {
     if (typeof value === 'string') {
       const trimmed = value.trim();
@@ -555,7 +607,7 @@ export class AssistantStreamSession {
     return fallback;
   }
 
-  private formatToolStartMessage(name: string | undefined) {
+  private getToolStartMessage(name: string | undefined) {
     const trimmed = name?.trim();
     if (!trimmed) {
       return DEFAULT_TOOL_PROGRESS_MESSAGE;

--- a/app/lib/generative/thinking/progress.ts
+++ b/app/lib/generative/thinking/progress.ts
@@ -1,0 +1,151 @@
+import type {ConversationThinkingUpdate} from '~/types/conversation';
+
+export const INITIAL_PROGRESS_STEP = 'Understanding your request';
+export const SUMMARY_PROGRESS_STEP = 'Writing the summary';
+
+type ToolProgressDefinition = {
+  stepLabel: string;
+  bulletLabel: string;
+};
+
+const TOOL_PROGRESS_BY_NAME: Record<string, ToolProgressDefinition> = {
+  store_reference_context: {
+    stepLabel: 'Reviewing previous conversation',
+    bulletLabel: 'Using messages and products from earlier in the chat',
+  },
+  discover_facets: {
+    stepLabel: 'Finding matching products',
+    bulletLabel: 'Checking related categories and facets',
+  },
+  coveo_commerce_catalog_facets: {
+    stepLabel: 'Finding matching products',
+    bulletLabel: 'Checking related categories and facets',
+  },
+  query_suggest: {
+    stepLabel: 'Refining the search',
+    bulletLabel: 'Using query suggestions to improve the search terms',
+  },
+  coveo_query_suggest: {
+    stepLabel: 'Refining the search',
+    bulletLabel: 'Using query suggestions to improve the search terms',
+  },
+  search_discovery: {
+    stepLabel: 'Finding matching products',
+    bulletLabel: 'Searching the catalog for products that match the request',
+  },
+  search_comparison: {
+    stepLabel: 'Finding comparable products',
+    bulletLabel: 'Searching for products with attributes to compare',
+  },
+  search_bundle: {
+    stepLabel: 'Finding bundle options',
+    bulletLabel: 'Searching for complementary products that work together',
+  },
+  search_research: {
+    stepLabel: 'Researching product attributes',
+    bulletLabel: 'Searching for product details for deeper guidance',
+  },
+  coveo_commerce_search: {
+    stepLabel: 'Searching the product catalog',
+    bulletLabel: 'Retrieving relevant products from the product catalog',
+  },
+  store_render_plan: {
+    stepLabel: 'Organizing the best options',
+    bulletLabel: 'Planning how to display the selected results',
+  },
+  render_carousel: {
+    stepLabel: 'Preparing results',
+    bulletLabel: 'Building a product carousel from the selected options',
+  },
+  render_product_carousel: {
+    stepLabel: 'Preparing results',
+    bulletLabel: 'Building a product carousel from the selected options',
+  },
+  render_comparison_table: {
+    stepLabel: 'Preparing the comparison',
+    bulletLabel: 'Building a side-by-side product comparison table',
+  },
+  render_comparison_summary: {
+    stepLabel: 'Summarizing the key tradeoffs',
+    bulletLabel: 'Highlighting the key differences between products',
+  },
+  render_bundle: {
+    stepLabel: 'Preparing the bundle',
+    bulletLabel: 'Organizing complementary products into a complete set',
+  },
+  render_product_research_card: {
+    stepLabel: 'Preparing product guidance',
+    bulletLabel: 'Building detailed guidance for the recommended product',
+  },
+  render_next_actions: {
+    stepLabel: 'Preparing next steps',
+    bulletLabel: 'Generating useful follow-up suggestions',
+  },
+};
+
+export type ThinkingProgressStep = {
+  id: string;
+  label: string;
+  bullets: string[];
+  isActive: boolean;
+};
+
+export function mapToolCallToProgress(
+  toolCallName: string | null | undefined,
+): ToolProgressDefinition | null {
+  if (!toolCallName) {
+    return null;
+  }
+
+  const normalized = toolCallName.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  return TOOL_PROGRESS_BY_NAME[normalized] ?? null;
+}
+
+export function buildThinkingProgressSteps(
+  updates: ConversationThinkingUpdate[],
+  isStreaming: boolean,
+): ThinkingProgressStep[] {
+  const steps: Array<{
+    id: string;
+    label: string;
+    bullets: string[];
+  }> = [];
+
+  for (const update of updates) {
+    const text = update.text.trim();
+    if (!text || update.kind === 'reasoning') {
+      continue;
+    }
+
+    if (update.kind === 'status') {
+      if (steps.at(-1)?.label === text) {
+        continue;
+      }
+
+      steps.push({
+        id: update.id,
+        label: text,
+        bullets: [],
+      });
+      continue;
+    }
+
+    const currentStep = steps.at(-1);
+    if (!currentStep) {
+      continue;
+    }
+
+    if (!currentStep.bullets.includes(text)) {
+      currentStep.bullets.push(text);
+    }
+  }
+
+  return steps.map((step, index) => ({
+    ...step,
+    isActive: isStreaming && index === steps.length - 1,
+  }));
+}

--- a/app/lib/generative/thinking/progress.ts
+++ b/app/lib/generative/thinking/progress.ts
@@ -8,6 +8,12 @@ type ToolProgressDefinition = {
   bulletLabel: string;
 };
 
+export const SKIPPED_PROGRESS_TOOL_NAMES = ['register_products'] as const;
+
+const SKIPPED_PROGRESS_TOOL_NAME_SET = new Set<string>(
+  SKIPPED_PROGRESS_TOOL_NAMES,
+);
+
 const TOOL_PROGRESS_BY_NAME: Record<string, ToolProgressDefinition> = {
   store_reference_context: {
     stepLabel: 'Reviewing previous conversation',
@@ -102,7 +108,26 @@ export function mapToolCallToProgress(
     return null;
   }
 
+  if (SKIPPED_PROGRESS_TOOL_NAME_SET.has(normalized)) {
+    return null;
+  }
+
   return TOOL_PROGRESS_BY_NAME[normalized] ?? null;
+}
+
+export function shouldSkipToolCallInProgress(
+  toolCallName: string | null | undefined,
+): boolean {
+  if (!toolCallName) {
+    return false;
+  }
+
+  const normalized = toolCallName.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  return SKIPPED_PROGRESS_TOOL_NAME_SET.has(normalized);
 }
 
 export function buildThinkingProgressSteps(


### PR DESCRIPTION
**Description**
This PR replaces the raw thinking log with a shopper-facing progress panel driven by live streamed events.

It introduces a dedicated progress-mapping layer for commerce and demo-agent tool calls, updates the stream session to derive visible progress from `TOOL_CALL_START` and `TEXT_MESSAGE_START` instead of reasoning text, and ignores raw reasoning/error noise in the panel. The UI is also reworked into a cleaner step timeline that shows the current step, grouped bullets, and a clearer completed state.

**What changed**
- Added `app/lib/generative/thinking/progress.ts` to map tool events to step labels and user-facing bullet copy.
- Updated `assistant-stream-session.ts` to:
  - initialize with a default request-understanding state
  - advance steps from live tool calls
  - switch to summary on assistant `TEXT_MESSAGE_START`
  - dedupe repeated bullets within a step
  - suppress raw reasoning text and tool error noise from the panel
- Redesigned `ThinkingStatusPanel.tsx` into a timeline-style progress view with:
  - grouped steps instead of a flat log
  - cleaner collapsed/expanded current-step handling
  - neutral completed-state treatment
 
<img width="1095" height="664" alt="Screenshot 2026-05-05 at 6 42 49 PM" src="https://github.com/user-attachments/assets/7160286c-41a3-47ab-b3d1-fc3473fb6dd8" />

