### PR TITLE
COMSHOPX-799 COMSHOPX-777 COMSHOPX-772 Added copy log function

### DIFF
--- a/app/components/Generative/ConversationSidebar.tsx
+++ b/app/components/Generative/ConversationSidebar.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import cx from '~/lib/cx';
 import {formatRelativeTime} from '~/lib/generative/conversation';
 import {
@@ -11,6 +11,7 @@ export function ConversationSidebar() {
   const [copiedConversationId, setCopiedConversationId] = useState<
     string | null
   >(null);
+  const copiedStateResetTimeoutRef = useRef<number | null>(null);
   const {conversations, activeConversationId} = useConversationsState();
   const {
     onSelectConversation,
@@ -18,6 +19,15 @@ export function ConversationSidebar() {
     onNewConversation,
     onCopyConversationDebugLog,
   } = useConversationActions();
+
+  useEffect(() => {
+    return () => {
+      if (copiedStateResetTimeoutRef.current !== null) {
+        window.clearTimeout(copiedStateResetTimeoutRef.current);
+      }
+    };
+  }, []);
+
   return (
     <aside
       className={cx(
@@ -150,10 +160,19 @@ export function ConversationSidebar() {
                               return;
                             }
                             setCopiedConversationId(conversation.localId);
-                            window.setTimeout(() => {
+
+                            if (copiedStateResetTimeoutRef.current !== null) {
+                              window.clearTimeout(
+                                copiedStateResetTimeoutRef.current,
+                              );
+                            }
+
+                            copiedStateResetTimeoutRef.current =
+                              window.setTimeout(() => {
                               setCopiedConversationId((current) =>
                                 current === conversation.localId ? null : current,
                               );
+                              copiedStateResetTimeoutRef.current = null;
                             }, 1600);
                           }}
                           className={cx(

--- a/app/components/Generative/ConversationSidebar.tsx
+++ b/app/components/Generative/ConversationSidebar.tsx
@@ -8,9 +8,16 @@ import {
 
 export function ConversationSidebar() {
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [copiedConversationId, setCopiedConversationId] = useState<
+    string | null
+  >(null);
   const {conversations, activeConversationId} = useConversationsState();
-  const {onSelectConversation, onDeleteConversation, onNewConversation} =
-    useConversationActions();
+  const {
+    onSelectConversation,
+    onDeleteConversation,
+    onNewConversation,
+    onCopyConversationDebugLog,
+  } = useConversationActions();
   return (
     <aside
       className={cx(
@@ -133,14 +140,75 @@ export function ConversationSidebar() {
                           {formatRelativeTime(conversation.updatedAt)}
                         </span>
                       </button>
-                      <button
-                        type="button"
-                        onClick={() => onDeleteConversation(conversation)}
-                        className="mr-2 mt-2 self-start rounded-full p-1 text-xs text-slate-400 transition hover:bg-rose-50 hover:text-rose-500"
-                        aria-label="Delete conversation"
-                      >
-                        ✕
-                      </button>
+                      <div className="mr-2 mt-2 flex items-center gap-1 self-start">
+                        <button
+                          type="button"
+                          onClick={async () => {
+                            const didCopy =
+                              await onCopyConversationDebugLog(conversation);
+                            if (!didCopy) {
+                              return;
+                            }
+                            setCopiedConversationId(conversation.localId);
+                            window.setTimeout(() => {
+                              setCopiedConversationId((current) =>
+                                current === conversation.localId ? null : current,
+                              );
+                            }, 1600);
+                          }}
+                          className={cx(
+                            'rounded-full p-1.5 text-xs transition',
+                            copiedConversationId === conversation.localId
+                              ? 'bg-emerald-50 text-emerald-600'
+                              : 'text-slate-400 hover:bg-slate-100 hover:text-slate-600',
+                          )}
+                          aria-label="Copy debug log"
+                          title={
+                            copiedConversationId === conversation.localId
+                              ? 'Copied'
+                              : 'Copy debug log'
+                          }
+                        >
+                          {copiedConversationId === conversation.localId ? (
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M5 13l4 4L19 7"
+                              />
+                            </svg>
+                          ) : (
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-8 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                              />
+                            </svg>
+                          )}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onDeleteConversation(conversation)}
+                          className="rounded-full p-1 text-xs text-slate-400 transition hover:bg-rose-50 hover:text-rose-500"
+                          aria-label="Delete conversation"
+                          title="Delete conversation"
+                        >
+                          ✕
+                        </button>
+                      </div>
                     </div>
                   </li>
                 );

--- a/app/components/Generative/ResponseContent/components/ComparisonTable.tsx
+++ b/app/components/Generative/ResponseContent/components/ComparisonTable.tsx
@@ -31,6 +31,9 @@ interface ComparisonTableProps {
 
 const SKELETON_COLUMNS = 3;
 const SKELETON_ROWS = 4;
+const LABEL_COLUMN_WIDTH_CLASS = 'w-28 min-w-[7rem]';
+const PRODUCT_COLUMN_WIDTH_CLASS = 'w-[18rem] min-w-[18rem]';
+const COMPACT_PRODUCT_COLUMN_WIDTH_CLASS = 'w-[13rem] min-w-[13rem]';
 
 // border-r + border-b only: the wrapper div provides the top and left outer edges.
 // border-separate (not border-collapse) prevents any interaction with the wrapper border.
@@ -45,17 +48,23 @@ const CELL_LAST_BOTH = 'border-gray-200'; // last col + last row
 function ComparisonTableSkeleton() {
   return (
     <div className="w-full overflow-x-auto">
-      <div className="border border-gray-200 rounded-lg overflow-hidden">
-        <table className="min-w-full border-separate border-spacing-0 animate-pulse">
+      <div className="inline-block min-w-full border border-gray-200 rounded-lg overflow-hidden align-top">
+        <table className="w-max min-w-full border-separate border-spacing-0 animate-pulse">
+          <colgroup>
+            <col className={LABEL_COLUMN_WIDTH_CLASS} />
+            {Array.from({length: SKELETON_COLUMNS}).map((_, i) => (
+              <col key={i} className={PRODUCT_COLUMN_WIDTH_CLASS} />
+            ))}
+          </colgroup>
           <thead>
             <tr>
-              <th className={`${CELL} px-4 py-3 w-28 bg-white`} />
+              <th className={`${CELL} ${LABEL_COLUMN_WIDTH_CLASS} px-4 py-3 bg-white`} />
               {Array.from({length: SKELETON_COLUMNS}).map((_, i) => {
                 const isLastCol = i === SKELETON_COLUMNS - 1;
                 return (
                   <th
                     key={i}
-                    className={`${isLastCol ? CELL_LAST_COL : CELL} px-4 py-5 bg-white`}
+                    className={`${isLastCol ? CELL_LAST_COL : CELL} ${PRODUCT_COLUMN_WIDTH_CLASS} px-4 py-5 bg-white`}
                   >
                     <div className="w-full h-48 rounded-lg bg-gray-200 mb-3" />
                     <div className="h-4 rounded bg-gray-200 w-3/4 mx-auto mb-1" />
@@ -119,6 +128,13 @@ export function ComparisonTable({
 }: ComparisonTableProps) {
   const [drawerProduct, setDrawerProduct] = useState<ComparisonProduct | null>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const isCompactComparison = products.length > 3;
+  const productColumnWidthClass = isCompactComparison
+    ? COMPACT_PRODUCT_COLUMN_WIDTH_CLASS
+    : PRODUCT_COLUMN_WIDTH_CLASS;
+  const productImageClass = isCompactComparison
+    ? 'h-[150px] w-[150px]'
+    : 'h-[200px] w-[200px]';
 
   const openDrawer = (product: ComparisonProduct) => {
     setDrawerProduct(product);
@@ -139,14 +155,23 @@ export function ComparisonTable({
         <h2 className="text-lg font-semibold text-gray-900 mb-4">{headline}</h2>
       )}
       {/* border + rounded-lg on wrapper; overflow-hidden clips cells to rounded corners cleanly */}
-      <div className="border border-gray-200 rounded-lg overflow-hidden">
-        <table className="min-w-full border-separate border-spacing-0">
+      <div className="inline-block min-w-full border border-gray-200 rounded-lg overflow-hidden align-top">
+        <table className="w-max min-w-full border-separate border-spacing-0">
+          <colgroup>
+            <col className={LABEL_COLUMN_WIDTH_CLASS} />
+            {products.map((product) => (
+              <col
+                key={product.productId}
+                className={productColumnWidthClass}
+              />
+            ))}
+          </colgroup>
           {/* ── Column headers ── */}
           <thead>
             <tr>
               {/* "Product" label — top-left, vertically top-aligned */}
               <th
-                className={`${CELL} px-4 py-4 w-28 text-left text-sm font-medium text-gray-500 align-top whitespace-nowrap bg-white`}
+                className={`${CELL} ${LABEL_COLUMN_WIDTH_CLASS} px-4 py-4 text-left text-sm font-medium text-gray-500 align-top whitespace-nowrap bg-white`}
               >
                 Product
               </th>
@@ -158,7 +183,7 @@ export function ComparisonTable({
                 return (
                   <th
                     key={product.productId}
-                    className={`${isLastCol ? CELL_LAST_COL : CELL} px-4 py-4 text-center align-top ${
+                    className={`${isLastCol ? CELL_LAST_COL : CELL} ${productColumnWidthClass} px-4 py-4 text-center align-top ${
                       isRecommended ? 'bg-indigo-50' : 'bg-white'
                     }`}
                   >
@@ -184,9 +209,13 @@ export function ComparisonTable({
                       <img
                         src={product.imageUrl}
                         alt={product.name}
-                        className="h-[200px] w-[200px] mx-auto object-cover bg-gray-50 group-hover:opacity-90 transition-opacity"
+                        className={`${productImageClass} mx-auto object-cover bg-gray-50 group-hover:opacity-90 transition-opacity`}
                       />
-                      <p className="mt-3 text-sm font-semibold text-gray-900 leading-snug truncate text-center">
+                      <p
+                        className={`mt-3 font-semibold text-gray-900 leading-snug text-center ${
+                          isCompactComparison ? 'text-[13px]' : 'text-sm'
+                        }`}
+                      >
                         {product.name}
                       </p>
                     </button>
@@ -257,11 +286,13 @@ export function ComparisonTable({
                   return (
                     <td
                       key={product.productId}
-                      className={`${isLastCol ? CELL_LAST_COL : CELL} px-4 py-3.5 text-sm text-gray-700 text-center ${
+                      className={`${isLastCol ? CELL_LAST_COL : CELL} ${productColumnWidthClass} px-4 py-3.5 text-sm text-gray-700 text-center align-top ${
                         isRecommended ? 'bg-indigo-50' : 'bg-white'
                       }`}
                     >
-                      {formatAttributeValue(product[attr])}
+                      <div className="whitespace-normal break-words">
+                        {formatAttributeValue(product[attr])}
+                      </div>
                     </td>
                   );
                 })}

--- a/app/lib/generative/context.tsx
+++ b/app/lib/generative/context.tsx
@@ -7,6 +7,9 @@ type ConversationActions = {
   onNewConversation: () => void;
   onSelectConversation: (conversation: ConversationRecord) => void;
   onDeleteConversation: (conversation: ConversationRecord) => void;
+  onCopyConversationDebugLog: (
+    conversation: ConversationRecord,
+  ) => Promise<boolean>;
 };
 
 type StreamingActions = {
@@ -60,11 +63,13 @@ export function useConversationActions(): ConversationActions {
       onNewConversation: actions.onNewConversation,
       onSelectConversation: actions.onSelectConversation,
       onDeleteConversation: actions.onDeleteConversation,
+      onCopyConversationDebugLog: actions.onCopyConversationDebugLog,
     }),
     [
       actions.onNewConversation,
       actions.onSelectConversation,
       actions.onDeleteConversation,
+      actions.onCopyConversationDebugLog,
     ],
   );
 }
@@ -129,6 +134,7 @@ type GenerativeProviderProps = {
   onNewConversation: () => void;
   onSelectConversation: (conversation: ConversationRecord) => void;
   onDeleteConversation: (conversation: ConversationRecord) => void;
+  onCopyConversationDebugLog: (conversation: ConversationRecord) => Promise<boolean>;
   onSendMessage: (message: string) => void;
   onStop: () => void;
   onToggleThinking: (messageId: string, next: boolean) => void;
@@ -150,6 +156,7 @@ export function GenerativeProvider({
   onNewConversation,
   onSelectConversation,
   onDeleteConversation,
+  onCopyConversationDebugLog,
   onSendMessage,
   onStop,
   onToggleThinking,
@@ -160,6 +167,7 @@ export function GenerativeProvider({
       onNewConversation,
       onSelectConversation,
       onDeleteConversation,
+      onCopyConversationDebugLog,
       onSendMessage,
       onStop,
       onToggleThinking,
@@ -169,6 +177,7 @@ export function GenerativeProvider({
       onNewConversation,
       onSelectConversation,
       onDeleteConversation,
+      onCopyConversationDebugLog,
       onSendMessage,
       onStop,
       onToggleThinking,

--- a/app/lib/generative/conversation/debug-log.ts
+++ b/app/lib/generative/conversation/debug-log.ts
@@ -270,7 +270,7 @@ function isVisibleMessage(message: ConversationMessage) {
 export function buildConversationDebugLog(
   conversation: ConversationRecord,
   options: {currentUrl?: string} = {},
-) {
+): string {
   const visibleMessages = conversation.messages.filter(isVisibleMessage);
   const lines = [
     '# Conversation Debug Log',

--- a/app/lib/generative/conversation/debug-log.ts
+++ b/app/lib/generative/conversation/debug-log.ts
@@ -1,0 +1,303 @@
+import type {Product} from '@coveo/headless-react/ssr-commerce';
+import type {SerializableSurfaceState} from '~/lib/generative/a2ui/surface-manager';
+import {resolveProductId} from '~/lib/generative/product/product-identifier';
+import type {ConversationMessage} from '~/types/conversation';
+import type {ConversationRecord} from './record';
+
+function formatValue(value: string | null | undefined) {
+  return value && value.trim().length > 0 ? value : '-';
+}
+
+function getValueAtPointer(data: Record<string, unknown>, path: string): unknown {
+  if (!path || path === '/') {
+    return data;
+  }
+
+  const segments = path
+    .split('/')
+    .slice(1)
+    .map((segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~'));
+
+  let current: unknown = data;
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object') {
+      return null;
+    }
+
+    if (Array.isArray(current)) {
+      const index = parseInt(segment, 10);
+      if (Number.isNaN(index) || index < 0 || index >= current.length) {
+        return null;
+      }
+      current = current[index];
+      continue;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+    if (current === undefined) {
+      return null;
+    }
+  }
+
+  return current;
+}
+
+function collectProductCandidates(source: unknown, bucket: Product[]) {
+  if (!source || typeof source !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(source)) {
+    source.forEach((entry) => collectProductCandidates(entry, bucket));
+    return;
+  }
+
+  const record = source as Record<string, unknown>;
+  const productId = resolveProductId(record);
+  const name =
+    typeof record.ec_name === 'string' && record.ec_name.trim().length > 0
+      ? record.ec_name.trim()
+      : null;
+
+  if (productId || name) {
+    bucket.push(record as unknown as Product);
+  }
+
+  Object.values(record).forEach((value) => {
+    if (value && typeof value === 'object') {
+      collectProductCandidates(value, bucket);
+    }
+  });
+}
+
+function dedupeProducts(products: Product[]) {
+  const seen = new Set<string>();
+
+  return products.filter((product) => {
+    const record = product as unknown as Record<string, unknown>;
+    const productId = resolveProductId(record) ?? '';
+    const name =
+      typeof record.ec_name === 'string' && record.ec_name.trim().length > 0
+        ? record.ec_name.trim()
+        : '';
+    const key = productId || name;
+
+    if (!key || seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+function extractProductsFromSurfaces(
+  a2uiSurfaces: Record<string, SerializableSurfaceState> | undefined,
+) {
+  if (!a2uiSurfaces) {
+    return [];
+  }
+
+  const products: Product[] = [];
+  Object.values(a2uiSurfaces).forEach((surface) => {
+    collectProductCandidates(surface.dataModelData, products);
+  });
+
+  return dedupeProducts(products);
+}
+
+function formatProducts(products: Product[]) {
+  if (products.length === 0) {
+    return '';
+  }
+
+  const lines = products
+    .map((product) => {
+      const record = product as unknown as Record<string, unknown>;
+      const productId = resolveProductId(record);
+      const name =
+        typeof record.ec_name === 'string' && record.ec_name.trim().length > 0
+          ? record.ec_name.trim()
+          : null;
+
+      if (!productId && !name) {
+        return null;
+      }
+
+      const brand =
+        typeof record.ec_brand === 'string' && record.ec_brand.trim().length > 0
+          ? record.ec_brand.trim()
+          : null;
+      const price =
+        record.ec_promo_price != null && String(record.ec_promo_price).trim().length > 0
+          ? record.ec_promo_price
+          : record.ec_price;
+      const currency =
+        typeof record.ec_currency === 'string' && record.ec_currency.trim().length > 0
+          ? record.ec_currency.trim()
+          : null;
+      const url =
+        typeof record.clickUri === 'string' && record.clickUri.trim().length > 0
+          ? record.clickUri.trim()
+          : typeof record.url === 'string' && record.url.trim().length > 0
+            ? record.url.trim()
+            : null;
+
+      const details = [
+        brand ? `brand: ${brand}` : null,
+        price !== undefined && price !== null ? `price: ${String(price)}${currency ? ` ${currency}` : ''}` : null,
+        url ? `url: ${url}` : null,
+      ].filter(Boolean);
+
+      return `- ${name ?? 'Unnamed product'}${productId ? ` (${productId})` : ''}${details.length ? ` | ${details.join(' | ')}` : ''}`;
+    })
+    .filter(Boolean) as string[];
+
+  return lines.length > 0 ? `\nProducts:\n${lines.join('\n')}` : '';
+}
+
+function extractFollowupActions(
+  a2uiSurfaces: Record<string, SerializableSurfaceState> | undefined,
+) {
+  if (!a2uiSurfaces) {
+    return [];
+  }
+
+  const actions: Array<{text: string; type: string}> = [];
+
+  Object.values(a2uiSurfaces).forEach((surface) => {
+    surface.components.forEach((component) => {
+      if (component.catalogComponentId !== 'NextActionsBar') {
+        return;
+      }
+
+      const props = (component.component as Record<string, unknown>)[
+        component.catalogComponentId
+      ] as Record<string, unknown> | undefined;
+      const actionBinding = props?.actions as {dataBinding?: string} | undefined;
+      const rawActions =
+        typeof actionBinding?.dataBinding === 'string'
+          ? getValueAtPointer(
+              surface.dataModelData as Record<string, unknown>,
+              actionBinding.dataBinding,
+            )
+          : null;
+
+      if (!Array.isArray(rawActions)) {
+        return;
+      }
+
+      rawActions.forEach((raw) => {
+        if (!raw || typeof raw !== 'object') {
+          return;
+        }
+
+        const record = raw as Record<string, unknown>;
+        const text =
+          typeof record.text === 'string' ? record.text.trim() : '';
+        if (!text) {
+          return;
+        }
+
+        actions.push({
+          text,
+          type:
+            typeof record.type === 'string' && record.type.trim().length > 0
+              ? record.type.trim()
+              : 'followup',
+        });
+      });
+    });
+  });
+
+  const seen = new Set<string>();
+  return actions.filter((action) => {
+    const key = `${action.type}::${action.text}`;
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+function formatFollowupActions(actions: Array<{text: string; type: string}>) {
+  if (actions.length === 0) {
+    return '';
+  }
+
+  return `\nFollow-up actions:\n${actions
+    .map((action) => `- [${action.type}] ${action.text}`)
+    .join('\n')}`;
+}
+
+function formatMessageContent(content: string) {
+  const trimmed = content.trim();
+  return trimmed ? trimmed : '[no content]';
+}
+
+function formatMessageEntry(message: ConversationMessage) {
+  const a2uiSurfaces = message.metadata?.a2uiSurfaces as
+    | Record<string, SerializableSurfaceState>
+    | undefined;
+  const products = dedupeProducts([
+    ...(message.metadata?.products ?? []),
+    ...extractProductsFromSurfaces(a2uiSurfaces),
+  ]);
+  const productBlock = formatProducts(products);
+  const followupBlock = formatFollowupActions(
+    extractFollowupActions(a2uiSurfaces),
+  );
+
+  return [formatMessageContent(message.content), productBlock, followupBlock]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function isVisibleMessage(message: ConversationMessage) {
+  if (message.isAutoRetry) {
+    return false;
+  }
+
+  const isEphemeralStatusMessage =
+    Boolean(message.ephemeral) &&
+    (message.kind === 'status' || message.kind === 'tool');
+
+  return !isEphemeralStatusMessage;
+}
+
+export function buildConversationDebugLog(
+  conversation: ConversationRecord,
+  options: {currentUrl?: string} = {},
+) {
+  const visibleMessages = conversation.messages.filter(isVisibleMessage);
+  const lines = [
+    '# Conversation Debug Log',
+    '',
+    `Title: ${conversation.title}`,
+    `Local ID: ${conversation.localId}`,
+    `Session ID: ${formatValue(conversation.sessionId)}`,
+    `Conversation Token: ${formatValue(conversation.conversationToken)}`,
+    `Created At: ${conversation.createdAt}`,
+    `Updated At: ${conversation.updatedAt}`,
+    `URL: ${formatValue(options.currentUrl)}`,
+    '',
+    '## Messages',
+  ];
+
+  if (visibleMessages.length === 0) {
+    lines.push('', 'No messages.');
+    return lines.join('\n');
+  }
+
+  visibleMessages.forEach((message, index) => {
+    lines.push(
+      '',
+      `${index + 1}. [${message.role}] [${message.kind}] ${message.createdAt}`,
+      formatMessageEntry(message),
+    );
+  });
+
+  return lines.join('\n');
+}

--- a/app/routes/($locale).generative.tsx
+++ b/app/routes/($locale).generative.tsx
@@ -15,6 +15,7 @@ import {
   type ConversationRecord,
   createEmptyConversation,
 } from '~/lib/generative/conversation';
+import {buildConversationDebugLog} from '~/lib/generative/conversation/debug-log';
 import {useAssistantStreaming} from '~/lib/generative/use-assistant-streaming';
 import {useConversationState} from '~/lib/generative/conversation/use-conversation-state';
 import {useConversationUrlSync} from '~/lib/generative/view/use-conversation-url-sync';
@@ -287,6 +288,25 @@ export default function GenerativeShoppingAssistant() {
     ],
   );
 
+  const handleCopyConversationDebugLog = useCallback(
+    async (conversation: ConversationRecord) => {
+      if (!navigator.clipboard?.writeText) {
+        return false;
+      }
+
+      try {
+        const log = buildConversationDebugLog(conversation, {
+          currentUrl: window.location.href,
+        });
+        await navigator.clipboard.writeText(log);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [],
+  );
+
   const suggestedPrompts = useMemo(
     () => [
       'Build a beginner surfing kit with budget, mid-range, and premium options',
@@ -321,6 +341,7 @@ export default function GenerativeShoppingAssistant() {
       onNewConversation={handleNewConversation}
       onSelectConversation={handleSelectConversation}
       onDeleteConversation={handleDeleteConversation}
+      onCopyConversationDebugLog={handleCopyConversationDebugLog}
       onSendMessage={handleSuggestionClick}
       onStop={abortStream}
       onToggleThinking={toggleMessageExpansion}


### PR DESCRIPTION
Adds a “copy conversation debug log” capability to the Generative Shopping Assistant so support/debugging info for a conversation can be quickly copied from the UI.

Adds bug fix for [COMSHOPX-777](https://coveord.atlassian.net/browse/COMSHOPX-777) and [COMSHOPX-772](https://coveord.atlassian.net/browse/COMSHOPX-772) for comparison table layout related issue

Changes:

Introduces a buildConversationDebugLog utility that formats conversation metadata, messages, inferred products, and follow-up actions into a single text log.
Wires a new onCopyConversationDebugLog action through the Generative context/provider and route.
Adds a copy button to each conversation entry in the sidebar with a “Copied” success state.

<img width="335" height="543" alt="Screenshot 2026-05-11 at 11 07 15 AM" src="https://github.com/user-attachments/assets/2f5cd370-a94a-43f4-bce3-b52bc3682f6c" />






[COMSHOPX-777]: https://coveord.atlassian.net/browse/COMSHOPX-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[COMSHOPX-772]: https://coveord.atlassian.net/browse/COMSHOPX-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ