### PR TITLE
Add second badge placement batch on PDP/PLP/Search

### DIFF
--- a/app/components/Products/ImageGallery.tsx
+++ b/app/components/Products/ImageGallery.tsx
@@ -5,10 +5,12 @@ export function ImageGallery({
   product,
   defaultImgIdx,
   onImgSelect,
+  badges,
 }: {
   product: ProductFragment;
   defaultImgIdx: number;
   onImgSelect?: (index: number) => void;
+  badges?: React.ReactNode;
 }) {
   return (
     <TabGroup
@@ -53,6 +55,7 @@ export function ImageGallery({
             />
           </TabPanel>
         ))}
+        <div className="pointer-events-none">{badges}</div>
       </TabPanels>
     </TabGroup>
   );

--- a/app/components/Products/ProductBadges.tsx
+++ b/app/components/Products/ProductBadges.tsx
@@ -1,6 +1,6 @@
 import {
-  getBadgePlacementId,
-  getSecondaryBadgePlacementId,
+  getBottomRightBadgePlacementId,
+  getTopLeftBadgePlacementId,
   type ProductBadgePlacementContext,
 } from '~/lib/coveo/engine';
 
@@ -58,22 +58,22 @@ export function ProductBadges({
     return null;
   }
 
-  const matchingPlacement = badgePlacements.find(
-    ({placementId}) => placementId === getBadgePlacementId(context),
+  const topLeftPlacement = badgePlacements.find(
+    ({placementId}) => placementId === getTopLeftBadgePlacementId(context),
   );
-  const secondaryPlacement = badgePlacements.find(
-    ({placementId}) => placementId === getSecondaryBadgePlacementId(context),
+  const bottomRightPlacement = badgePlacements.find(
+    ({placementId}) => placementId === getBottomRightBadgePlacementId(context),
   );
-  const secondaryBadges = secondaryPlacement?.badges.slice(0, 3) ?? [];
+  const bottomRightBadges = bottomRightPlacement?.badges.slice(0, 3) ?? [];
 
   return (
     <>
-      {!!matchingPlacement?.badges.length && (
+      {!!topLeftPlacement?.badges.length && (
         <div className="pointer-events-none absolute left-2 top-2 z-[1] flex max-w-[calc(100%-1rem)] flex-wrap gap-2">
-          <BadgeList badges={matchingPlacement.badges} />
+          <BadgeList badges={topLeftPlacement.badges} />
         </div>
       )}
-      {secondaryBadges.length > 0 && (
+      {bottomRightBadges.length > 0 && (
         <div
           className={`pointer-events-none absolute bottom-2 right-2 z-[1] flex max-w-[calc(100%-1rem)] flex-wrap justify-end gap-2 ${
             context !== 'pdp'
@@ -81,7 +81,7 @@ export function ProductBadges({
               : ''
           }`}
         >
-          <BadgeList badges={secondaryBadges} />
+          <BadgeList badges={bottomRightBadges} />
         </div>
       )}
     </>

--- a/app/components/Products/ProductBadges.tsx
+++ b/app/components/Products/ProductBadges.tsx
@@ -1,5 +1,6 @@
 import {
   getBadgePlacementId,
+  getSecondaryBadgePlacementId,
   type ProductBadgePlacementContext,
 } from '~/lib/coveo/engine';
 
@@ -60,14 +61,29 @@ export function ProductBadges({
   const matchingPlacement = badgePlacements.find(
     ({placementId}) => placementId === getBadgePlacementId(context),
   );
-
-  if (!matchingPlacement?.badges.length) {
-    return null;
-  }
+  const secondaryPlacement = badgePlacements.find(
+    ({placementId}) => placementId === getSecondaryBadgePlacementId(context),
+  );
+  const secondaryBadges = secondaryPlacement?.badges.slice(0, 3) ?? [];
 
   return (
-    <div className="pointer-events-none absolute left-2 top-2 z-[1] flex max-w-[calc(100%-1rem)] flex-wrap gap-2">
-      <BadgeList badges={matchingPlacement.badges} />
-    </div>
+    <>
+      {!!matchingPlacement?.badges.length && (
+        <div className="pointer-events-none absolute left-2 top-2 z-[1] flex max-w-[calc(100%-1rem)] flex-wrap gap-2">
+          <BadgeList badges={matchingPlacement.badges} />
+        </div>
+      )}
+      {secondaryBadges.length > 0 && (
+        <div
+          className={`pointer-events-none absolute bottom-2 right-2 z-[1] flex max-w-[calc(100%-1rem)] flex-wrap justify-end gap-2 ${
+            context !== 'pdp'
+              ? 'opacity-0 transition-opacity duration-150 group-hover:opacity-100'
+              : ''
+          }`}
+        >
+          <BadgeList badges={secondaryBadges} />
+        </div>
+      )}
+    </>
   );
 }

--- a/app/lib/coveo/engine.ts
+++ b/app/lib/coveo/engine.ts
@@ -30,26 +30,28 @@ export const coveoRecommendationSlotIds = {
   pdpUpperCarousel: '68f1384f-b27c-4355-ac9a-7b63ba084e71',
 } as const;
 
-export const coveoBadgePlacementIds = {
+export const coveoTopLeftBadgePlacementIds = {
   plp: 'a0d74b42-ff00-4c92-a9e7-0269ee9a1f32',
   search: 'bc4a5816-8e48-4960-8866-9765b99a422e',
   pdp: '18449c53-c9ba-4ddb-97fb-52cd1663242c',
 } as const satisfies Record<ProductBadgePlacementContext, string>;
 
-export function getBadgePlacementId(context: ProductBadgePlacementContext) {
-  return coveoBadgePlacementIds[context];
+export function getTopLeftBadgePlacementId(
+  context: ProductBadgePlacementContext,
+) {
+  return coveoTopLeftBadgePlacementIds[context];
 }
 
-export const coveoSecondaryBadgePlacementIds = {
+export const coveoBottomRightBadgePlacementIds = {
   plp: '497c7469-ca8c-4385-8099-7339927bcdf7',
   search: '7253a3f9-5f8b-43b0-a47d-7c6a0e5f11ff',
   pdp: '6cf94e23-e21e-4950-8acc-33dc739a6f0b',
 } as const satisfies Record<ProductBadgePlacementContext, string>;
 
-export function getSecondaryBadgePlacementId(
+export function getBottomRightBadgePlacementId(
   context: ProductBadgePlacementContext,
 ) {
-  return coveoSecondaryBadgePlacementIds[context];
+  return coveoBottomRightBadgePlacementIds[context];
 }
 
 /**

--- a/app/lib/coveo/engine.ts
+++ b/app/lib/coveo/engine.ts
@@ -40,6 +40,18 @@ export function getBadgePlacementId(context: ProductBadgePlacementContext) {
   return coveoBadgePlacementIds[context];
 }
 
+export const coveoSecondaryBadgePlacementIds = {
+  plp: '497c7469-ca8c-4385-8099-7339927bcdf7',
+  search: '7253a3f9-5f8b-43b0-a47d-7c6a0e5f11ff',
+  pdp: '6cf94e23-e21e-4950-8acc-33dc739a6f0b',
+} as const satisfies Record<ProductBadgePlacementContext, string>;
+
+export function getSecondaryBadgePlacementId(
+  context: ProductBadgePlacementContext,
+) {
+  return coveoSecondaryBadgePlacementIds[context];
+}
+
 /**
  * Placeholder token used for initial engine configuration.
  *

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -30,6 +30,7 @@ import {RecommendationProvider} from '~/components/Search/Context';
 import {
   engineDefinition,
   getBadgePlacementId,
+  getSecondaryBadgePlacementId,
   useEngine,
   useProductView,
 } from '~/lib/coveo/engine';
@@ -239,7 +240,10 @@ export default function Product() {
         ? buildProductEnrichment(engine, {
             options: {
               productId,
-              placementIds: [getBadgePlacementId('pdp')],
+              placementIds: [
+                getBadgePlacementId('pdp'),
+                getSecondaryBadgePlacementId('pdp'),
+              ],
             },
           })
         : null,
@@ -300,23 +304,23 @@ export default function Product() {
     <main className="pdp-container mx-auto max-w-7xl sm:px-6 sm:pt-16 lg:px-8">
       <div className="mx-auto max-w-2xl lg:max-w-none">
         <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-8">
-          <div className="relative">
-            <ProductBadges
-              badgePlacements={productBadgePlacements}
-              context="pdp"
-            />
-            <ImageGallery
-              product={product}
-              defaultImgIdx={defaultImageIdx}
-              onImgSelect={(idx) => {
-                setDefaultImageIdx(idx);
-                setColorParam(
-                  product.options.find((opt) => opt.name === 'Color')
-                    ?.optionValues[idx].name || '',
-                );
-              }}
-            />
-          </div>
+          <ImageGallery
+            product={product}
+            defaultImgIdx={defaultImageIdx}
+            onImgSelect={(idx) => {
+              setDefaultImageIdx(idx);
+              setColorParam(
+                product.options.find((opt) => opt.name === 'Color')
+                  ?.optionValues[idx].name || '',
+              );
+            }}
+            badges={
+              <ProductBadges
+                badgePlacements={productBadgePlacements}
+                context="pdp"
+              />
+            }
+          />
 
           <div className="mt-10 px-4 sm:mt-16 sm:px-0 lg:mt-0">
             <Description product={product} />

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -29,8 +29,8 @@ import {Sizes} from '~/components/Products/Sizes';
 import {RecommendationProvider} from '~/components/Search/Context';
 import {
   engineDefinition,
-  getBadgePlacementId,
-  getSecondaryBadgePlacementId,
+  getBottomRightBadgePlacementId,
+  getTopLeftBadgePlacementId,
   useEngine,
   useProductView,
 } from '~/lib/coveo/engine';
@@ -241,8 +241,8 @@ export default function Product() {
             options: {
               productId,
               placementIds: [
-                getBadgePlacementId('pdp'),
-                getSecondaryBadgePlacementId('pdp'),
+                getTopLeftBadgePlacementId('pdp'),
+                getBottomRightBadgePlacementId('pdp'),
               ],
             },
           })


### PR DESCRIPTION
## Summary
- Adds a second, independent badge placement batch (new placement IDs) rendered bottom-right on the product image, alongside the existing top-left batch from PR #75:
  - PDP (`6cf94e23-e21e-4950-8acc-33dc739a6f0b`): always visible, capped at 3 badges.
  - PLP (`497c7469-ca8c-4385-8099-7339927bcdf7`): hover-only, capped at 3 badges.
  - Search (`7253a3f9-5f8b-43b0-a47d-7c6a0e5f11ff`): hover-only, capped at 3 badges.
- Fixes PDP badge overlay positioning to anchor to the main image (the `TabPanels` aspect-ratio box) instead of the whole gallery block (image + thumbnails), which previously caused badges to render over the thumbnail strip.

## Test plan
- [x] Confirm the three new placement UUIDs are associated with their surfaces (PDP/PLP/Search) in the Coveo Merchandising Hub.
- [x] PDP: top-left (uncapped) and bottom-right (≤3, always visible) badges both render on the main image simultaneously.
- [x] PLP/Search: top-left badges always visible; bottom-right badges (≤3) appear only when hovering the card and disappear on mouse-out.
- [x] Confirm existing batch-1 top-left behavior is unaffected everywhere.
- [x] `npm run typecheck` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)